### PR TITLE
Configure RSpec

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,31 +44,28 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  # # This allows you to limit a spec run to individual examples or groups
+  # # you care about by tagging them with `:focus` metadata. When nothing
+  # # is tagged with `:focus`, all examples get run. RSpec also provides
+  # # aliases for `it`, `describe`, and `context` that include `:focus`
+  # # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
   config.filter_run_when_matching :focus
 
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
+  # # Allows RSpec to persist some state between runs in order to support
+  # # the `--only-failures` and `--next-failure` CLI options. We recommend
+  # # you configure your source control system to ignore this file.
+  # config.example_status_persistence_file_path = "spec/examples.txt"
 
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  # # Limits the available syntax to the non-monkey patched syntax that is
+  # # recommended. For more details, see:
+  # #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  # #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  # #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
   config.disable_monkey_patching!
 
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
+  # # Many RSpec users commonly either run the entire suite or an individual
+  # # file, and it's useful to allow more verbose output when running an
+  # # individual spec file.
   if config.files_to_run.one?
     # Use the documentation formatter for detailed output,
     # unless a formatter has already been configured
@@ -76,10 +73,10 @@ RSpec.configure do |config|
     config.default_formatter = "doc"
   end
 
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
+  # # Print the 10 slowest examples and example groups at the
+  # # end of the spec run, to help surface which specs are running
+  # # particularly slow.
+  # config.profile_examples = 10
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing
@@ -92,5 +89,4 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
-=end
 end


### PR DESCRIPTION
Turns on various optional RSpec configurations that make for nice defaults for the project. Especially: runs RSpec examples with random seeds.

Partially addresses #3.