### PR TITLE
Remove errant blank line from `EtdIndexer`

### DIFF
--- a/app/indexers/etd_indexer.rb
+++ b/app/indexers/etd_indexer.rb
@@ -9,7 +9,6 @@ class EtdIndexer < Hyrax::WorkIndexer
   # this behavior
   include Hyrax::IndexesLinkedMetadata
 
-
   # Uncomment this block if you want to add custom indexing behavior:
   # def generate_solr_document
   #  super.tap do |solr_doc|


### PR DESCRIPTION
The generator left this behind, and it slipped through due to the pending state on #63.