### PR TITLE
File attach spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,5 +69,6 @@ group :development, :test do
 end
 
 group :test do
-  gem 'capybara', '~> 2.15.4'
+  gem 'capybara',           '~> 2.15.4'
+  gem 'factory_girl_rails', '~> 4.8.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -632,6 +632,11 @@ GEM
       nokogiri (>= 1.4.3)
     erubis (2.7.0)
     execjs (2.7.0)
+    factory_girl (4.8.1)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.8.0)
+      factory_girl (~> 4.8.0)
+      railties (>= 3.0.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
     faraday-encoding (0.0.4)
@@ -1174,6 +1179,7 @@ DEPENDENCIES
   database_cleaner
   devise
   devise-guests (~> 0.6)
+  factory_girl_rails (~> 4.8.0)
   fcrepo_wrapper
   hyrax (= 2.0.0.beta4)
   jbuilder (~> 2.5)

--- a/spec/factories/etds.rb
+++ b/spec/factories/etds.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :etd do
+    title ['Comet in Moominland']
+
+    factory :public_etd do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+  end
+end

--- a/spec/factories/hyrax_uploaded_files.rb
+++ b/spec/factories/hyrax_uploaded_files.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :uploaded_file, aliases: [:pdf_upload], class: Hyrax::UploadedFile do
+    user
+    file File.open('spec/fixtures/files/pdf-sample.pdf')
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,3 @@
-require 'factory_girl'
-
 FactoryGirl.define do
   factory :user do
     sequence :email do |n|

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,11 @@
+require 'factory_girl'
+
+FactoryGirl.define do
+  factory :user do
+    sequence :email do |n|
+      "test_user_#{n}@example.com"
+    end
+
+    password 'password'
+  end
+end

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -7,14 +7,7 @@ include Warden::Test::Helpers
 RSpec.feature 'Create a Etd', js: false do
   context 'a logged in user' do
     let(:title) { 'Comet in Moominland' }
-
-    let(:user_attributes) do
-      { email: 'test@example.com' }
-    end
-
-    let(:user) do
-      User.new(user_attributes) { |u| u.save(validate: false) }
-    end
+    let(:user)  { FactoryGirl.create(:user) }
 
     before { login_as user }
 

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -1,5 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe Etd do
+  subject(:etd) { FactoryGirl.create(:etd) }
+
   it_behaves_like 'a model with basic metadata'
+
+  describe 'an attached pdf' do
+    let(:actor)  { Hyrax::Actors::FileSetActor.new(FileSet.create, user) }
+    let(:upload) { FactoryGirl.create(:pdf_upload) }
+    let(:user)   { FactoryGirl.create(:user) }
+
+    before do
+      actor.create_metadata({})
+      actor.create_content(upload)
+      actor.attach_to_work(etd)
+    end
+
+    it 'is the representative file' do
+      expect(etd.representative).to eq actor.file_set
+    end
+
+    it 'is the thumbnail' do
+      expect(etd.thumbnail).to eq actor.file_set
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,6 +44,8 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
+  config.include FactoryGirl::Syntax::Methods
+
   config.before(:suite) do
     ActiveFedora::Cleaner.clean!
     DatabaseCleaner.clean_with(:truncation)


### PR DESCRIPTION
Ensures that an attached PDF becomes the thumbnail and representative file for an ETD work.

To avoid code duplication, `User` creation in existing specs is moved to a factory.

Partially addresses #9 