### PR TITLE
Test ETD editing for depositors

### DIFF
--- a/spec/factories/etds.rb
+++ b/spec/factories/etds.rb
@@ -1,5 +1,14 @@
 FactoryGirl.define do
   factory :etd do
+    transient do
+      user { FactoryGirl.create(:user) }
+    end
+
+    # give the user edit access
+    after(:build) do |work, evaluator|
+      work.apply_depositor_metadata(evaluator.user.user_key)
+    end
+
     title ['Comet in Moominland']
 
     factory :public_etd do

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -3,15 +3,14 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-# NOTE: If you generated more than one work, you have to set "js: true"
 RSpec.feature 'Create a Etd', js: false do
-  context 'a logged in user' do
+  context 'as a logged in user' do
     let(:title) { 'Comet in Moominland' }
     let(:user)  { FactoryGirl.create(:user) }
 
     before { login_as user }
 
-    scenario do
+    scenario 'creating' do
       visit '/dashboard'
       click_link 'Works'
       click_link 'Add new work'
@@ -25,6 +24,20 @@ RSpec.feature 'Create a Etd', js: false do
       find('#with_files_submit').click
 
       expect(page).to have_content title
+    end
+
+    scenario 'editing' do
+      etd = FactoryGirl.create(:etd, user: user)
+
+      visit "concern/etds/#{etd.id}"
+      click_link 'Edit'
+
+      new_title = 'Finn Family Moomintroll'
+
+      fill_in 'Title', with: new_title
+      find('#with_files_submit').click
+
+      expect(page).to have_content new_title
     end
   end
 end


### PR DESCRIPTION
Check that the depositor can edit the title of an ETD through the UI.

Adds depositor data to the `:etd` factory to support creation of objects with a given user having edit access.

This is more work on #9 