### PR TITLE
Test access of public and restricted items

### DIFF
--- a/spec/factories/etds.rb
+++ b/spec/factories/etds.rb
@@ -2,11 +2,19 @@ FactoryGirl.define do
   factory :etd do
     transient do
       user { FactoryGirl.create(:user) }
+      pdf  { nil }
     end
 
     # give the user edit access
     after(:build) do |work, evaluator|
       work.apply_depositor_metadata(evaluator.user.user_key)
+
+      if evaluator.pdf
+        actor = Hyrax::Actors::FileSetActor.new(FileSet.create, evaluator.user)
+        actor.create_metadata({})
+        actor.create_content(evaluator.pdf)
+        actor.attach_to_work(work)
+      end
     end
 
     title ['Comet in Moominland']

--- a/spec/features/access_etd_spec.rb
+++ b/spec/features/access_etd_spec.rb
@@ -12,7 +12,9 @@ RSpec.feature 'Access an Etd', js: false do
     fill_in 'Search Hyrax', with: etd.first_title
     click_button 'Go'
 
-    expect(page).to have_css("li#document_#{etd.id}")
+    within(:css, "li#document_#{etd.id}") do
+      expect(page).to have_content etd.first_title
+    end
   end
 
   context 'with ingested file', :perform_enqueued do

--- a/spec/features/access_etd_spec.rb
+++ b/spec/features/access_etd_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.feature 'Access an Etd', :perform_enqueued, js: false do
+  let(:etd) { FactoryGirl.create(:public_etd, pdf: pdf) }
+  let(:pdf) { FactoryGirl.create(:pdf_upload) }
+
+  # Only enqueue the ingest job, not charactarization.
+  before { ActiveJob::Base.queue_adapter.filter = [IngestJob] }
+
+  scenario 'downloading' do
+    visit      "concern/etds/#{etd.id}"
+    click_link "Download \"#{etd.representative.first_title}\""
+
+    expect(page.response_headers['Content-Disposition']).to include 'attachment'
+  end
+end

--- a/spec/features/access_etd_spec.rb
+++ b/spec/features/access_etd_spec.rb
@@ -1,23 +1,34 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.feature 'Access an Etd', :perform_enqueued, js: false do
+RSpec.feature 'Access an Etd', js: false do
   let(:etd)         { FactoryGirl.create(:public_etd, pdf: pdf) }
   let(:pdf)         { FactoryGirl.create(:pdf_upload) }
   let(:private_etd) { FactoryGirl.create(:etd, pdf: pdf) }
 
-  # Only enqueue the ingest job, not charactarization.
-  before { ActiveJob::Base.queue_adapter.filter = [IngestJob] }
+  scenario 'searching submitted ETDs' do
+    visit '/'
 
-  scenario 'downloading' do
-    visit      "concern/etds/#{etd.id}"
-    click_link "Download \"#{etd.representative.first_title}\""
+    fill_in 'Search Hyrax', with: etd.first_title
+    click_button 'Go'
 
-    expect(page.response_headers['Content-Disposition']).to include 'attachment'
+    expect(page).to have_css("li#document_#{etd.id}")
   end
 
-  scenario 'downloading restricted' do
-    visit "concern/etds/#{private_etd.id}"
-    expect(page).not_to have_content 'Download'
+  context 'with ingested file', :perform_enqueued do
+    # Only enqueue the ingest job, not charactarization.
+    before { ActiveJob::Base.queue_adapter.filter = [IngestJob] }
+
+    scenario 'downloading' do
+      visit      "concern/etds/#{etd.id}"
+      click_link "Download \"#{etd.representative.first_title}\""
+
+      expect(page.response_headers['Content-Disposition']).to include 'attachment'
+    end
+
+    scenario 'downloading restricted' do
+      visit "concern/etds/#{private_etd.id}"
+      expect(page).not_to have_content 'Download'
+    end
   end
 end

--- a/spec/features/access_etd_spec.rb
+++ b/spec/features/access_etd_spec.rb
@@ -2,8 +2,9 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 RSpec.feature 'Access an Etd', :perform_enqueued, js: false do
-  let(:etd) { FactoryGirl.create(:public_etd, pdf: pdf) }
-  let(:pdf) { FactoryGirl.create(:pdf_upload) }
+  let(:etd)         { FactoryGirl.create(:public_etd, pdf: pdf) }
+  let(:pdf)         { FactoryGirl.create(:pdf_upload) }
+  let(:private_etd) { FactoryGirl.create(:etd, pdf: pdf) }
 
   # Only enqueue the ingest job, not charactarization.
   before { ActiveJob::Base.queue_adapter.filter = [IngestJob] }
@@ -13,5 +14,10 @@ RSpec.feature 'Access an Etd', :perform_enqueued, js: false do
     click_link "Download \"#{etd.representative.first_title}\""
 
     expect(page.response_headers['Content-Disposition']).to include 'attachment'
+  end
+
+  scenario 'downloading restricted' do
+    visit "concern/etds/#{private_etd.id}"
+    expect(page).not_to have_content 'Download'
   end
 end


### PR DESCRIPTION
Tests are added to check downloading an unprotected ETD as a non-logged in user and non-availability of download for restricted ETDs. A search spec for a public ETD is also added.

In support of this:

The `:etd` factory is extended to accept a `pdf` keyword argument which accepts a `Hyrax::UploadedFile`. If given the file will be attached to the work in a way similar to what happens in the actor stack on ingest.

A `:perform_enqueued` spec metadata element is introduced to setup (and tear down) the test queue adapter to perform jobs inline.

Closes #9
Closes #60 