### PR TITLE
Move custom matchers to `spec/support`

### DIFF
--- a/spec/support/matchers/have_editable_property.rb
+++ b/spec/support/matchers/have_editable_property.rb
@@ -1,0 +1,18 @@
+RSpec::Matchers.define :have_editable_property do |property, predicate|
+  match do |model|
+    values = ['Comet in Moominland', 'Moomin Midwinter']
+
+    expect { model.public_send("#{property}=", values) }
+      .to change { model.public_send(property).to_a }
+      .to contain_exactly(*values)
+
+    expect(model.resource.statements)
+      .to include(RDF::Statement(model.rdf_subject,
+                                 predicate,
+                                 'Comet in Moominland'),
+                  RDF::Statement(model.rdf_subject,
+                                 predicate,
+                                 'Moomin Midwinter'))
+    true
+  end
+end

--- a/spec/support/shared_examples/hyrax_basic_metadata.rb
+++ b/spec/support/shared_examples/hyrax_basic_metadata.rb
@@ -1,22 +1,3 @@
-RSpec::Matchers.define :have_editable_property do |property, predicate|
-  match do |model|
-    values = ['Comet in Moominland', 'Moomin Midwinter']
-
-    expect { model.public_send("#{property}=", values) }
-      .to change { model.public_send(property).to_a }
-      .to contain_exactly(*values)
-
-    expect(model.resource.statements)
-      .to include(RDF::Statement(model.rdf_subject,
-                                 predicate,
-                                 'Comet in Moominland'),
-                  RDF::Statement(model.rdf_subject,
-                                 predicate,
-                                 'Moomin Midwinter'))
-    true
-  end
-end
-
 RSpec.shared_examples 'a model with core metadata' do
   subject(:model) { described_class.new }
 


### PR DESCRIPTION
This is a nicer way of organizing code that will be usable project-wide.