### PR TITLE
Test metadata on search results indexes

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -51,4 +51,7 @@ RSpec.configure do |config|
     DatabaseCleaner.clean_with(:truncation)
     AdminSet.find_or_create_default_admin_set_id
   end
+
+  config.include(ControllerLevelHelpers, type: :view)
+  config.before(type: :view) { initialize_controller_helpers(view) }
 end

--- a/spec/support/controller_level_helpers.rb
+++ b/spec/support/controller_level_helpers.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module ControllerLevelHelpers
+  # This provides some common mock methods for view tests.
+  # These are normally provided by the controller.
+  module ControllerViewHelpers
+    def search_state
+      @search_state ||=
+        CatalogController
+        .search_state_class
+        .new(params, blacklight_config, controller)
+    end
+
+    # This allows you to set the configuration
+    # @example: view.blacklight_config = Blacklight::Configuration.new
+    attr_writer :blacklight_config
+
+    def blacklight_config
+      @blacklight_config ||= CatalogController.blacklight_config
+    end
+
+    def blacklight_configuration_context
+      @blacklight_configuration_context ||=
+        Blacklight::Configuration::Context.new(controller)
+    end
+  end
+
+  def initialize_controller_helpers(helper)
+    helper.extend ControllerViewHelpers
+  end
+end

--- a/spec/views/catalog/_index_list_default.html.erb_spec.rb
+++ b/spec/views/catalog/_index_list_default.html.erb_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe 'catalog/_index_list_default', type: :view do
+  let(:attributes) { { keyword: ['moomin', 'snorkmaiden'] } }
+  let!(:document)  { SolrDocument.new(etd.to_solr) }
+  let!(:etd)       { FactoryGirl.build(:etd, **attributes) }
+  let!(:presenter) { instance_double('Blacklight::IndexPresenter') }
+
+  before do
+    # @todo Set index_presenter on the view in a more realistic way.
+    #   does this belong in the controller view helpers?
+    allow(view).to receive(:index_presenter).and_return(presenter)
+    # @todo Build a more comprehensive IndexPresenter fake
+    allow(presenter).to receive(:field_value) { |field| "A value for #{field}" }
+
+    render 'catalog/index_list_default', document: document
+  end
+
+  # title appears in a different partial
+  it 'does not display the title in the metadata' do
+    expect(rendered).not_to include 'Title:'
+  end
+
+  it 'displays keywords' do
+    expect(rendered).to include '<span class="attribute-label h4">Keyword:</span>'
+  end
+end


### PR DESCRIPTION
This is intended to test requirements like appear on #54:

>  When I look at the catalog search results page I should see the keywords for each ETD

Tests that `keywords` show up on the search result index view.

Sets up a spec helper for views that depend on blacklight config.