### PR TITLE
Test presence of title in ttl export

### DIFF
--- a/spec/presenters/hyrax/etd_presenter_spec.rb
+++ b/spec/presenters/hyrax/etd_presenter_spec.rb
@@ -1,9 +1,16 @@
-# Generated via
-#  `rails generate hyrax:work Etd`
 require 'rails_helper'
 
-RSpec.describe Hyrax::EtdPresenter do
-  it "has tests" do
-    skip "Add your tests here"
+RSpec.describe Hyrax::EtdPresenter, type: :presenter do
+  subject(:presenter) { described_class.new(document, ability, request) }
+  let(:ability)       { nil }
+  let(:document)      { SolrDocument.new(etd.to_solr) }
+  let(:etd)           { FactoryGirl.create(:etd, id: 'moomin_id') }
+  let(:request)       { instance_double('Rack::Request', host: 'example.com') }
+
+  describe '#export_as_ttl' do
+    it 'has a title' do
+      expect(presenter.export_as_ttl)
+        .to include etd.class.properties['title'].predicate.to_base
+    end
   end
 end


### PR DESCRIPTION
We test this at the presenter level, trusting the routing and controllers to do their part.

The `EtdController` raises an unknown format error when `:ttl` is requested, so it's not clear to me how conneg is being dispatched for .ttl responses. I think we should eventually test that code locally as well if we can track down the path.