### PR TITLE
Test that exactly the correct facets exist

### DIFF
--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe CatalogController, type: :controller do
+  describe 'facets' do
+    let(:facets) do
+      controller
+        .blacklight_config
+        .facet_fields.keys
+        .map { |field| field.gsub(/\_s+im$/, '') }
+    end
+
+    let(:expected_facets) do
+      ['human_readable_type',
+       'resource_type',
+       'creator',
+       'contributor',
+       'keyword',
+       'subject',
+       'language',
+       'based_near_label',
+       'publisher',
+       'file_format',
+       'member_of_collections',
+       'generic_type']
+    end
+
+    it 'has exactly expected facets' do
+      expect(facets).to contain_exactly(*expected_facets)
+    end
+  end
+end


### PR DESCRIPTION
We check that the intended facet fields are in the blacklight config.

A view partial spec would be better (more robust, less tautological), but setting up the blacklight environment correctly was painful enough that this started to look like the best approach for this project.