### PR TITLE
Setup Resource Type

### DIFF
--- a/config/authorities/resource_types.yml
+++ b/config/authorities/resource_types.yml
@@ -1,41 +1,13 @@
 terms:
-  - id: Article
+  - id: article
     term: Article
-  - id: Audio
-    term: Audio
-  - id: Book
-    term: Book
-  - id: Capstone Project
-    term: Capstone Project
-  - id: Conference Proceeding
-    term: Conference Proceeding
-  - id: Dataset
-    term: Dataset
-  - id: Dissertation
+  - id: capstone
+    term: Capstone
+  - id: dissertation
     term: Dissertation
-  - id: Image
-    term: Image
-  - id: Journal
-    term: Journal
-  - id: Map or Cartographic Material
-    term: Map or Cartographic Material
-  - id: Masters Thesis
-    term: Masters Thesis
-  - id: Part of Book
-    term: Part of Book
-  - id: Poster
-    term: Poster
-  - id: Presentation
-    term: Presentation
-  - id: Project
-    term: Project
-  - id: Report
-    term: Report
-  - id: Research Paper
-    term: Research Paper
-  - id: Software or Program Code
-    term: Software or Program Code
-  - id: Video
-    term: Video
-  - id: Other
+  - id: portfolio
+    term: Portfolio
+  - id: thesis
+    term: Thesis
+  - id: other
     term: Other

--- a/spec/views/catalog/_index_list_default.html.erb_spec.rb
+++ b/spec/views/catalog/_index_list_default.html.erb_spec.rb
@@ -1,7 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe 'catalog/_index_list_default', type: :view do
-  let(:attributes) { { keyword: ['moomin', 'snorkmaiden'] } }
+  let(:attributes) do
+    { keyword:       ['moomin', 'snorkmaiden'],
+      resource_type: ['Moomin'] }
+  end
+
   let!(:document)  { SolrDocument.new(etd.to_solr) }
   let!(:etd)       { FactoryGirl.build(:etd, **attributes) }
   let!(:presenter) { instance_double('Blacklight::IndexPresenter') }
@@ -16,12 +20,14 @@ RSpec.describe 'catalog/_index_list_default', type: :view do
     render 'catalog/index_list_default', document: document
   end
 
-  # title appears in a different partial
-  it 'does not display the title in the metadata' do
-    expect(rendered).not_to include 'Title:'
+  # title appears in a different partial, not in the metadata listing
+  it 'does not display undesired fields' do
+    expect(rendered).not_to include 'title'
   end
 
-  it 'displays keywords' do
-    expect(rendered).to include '<span class="attribute-label h4">Keyword:</span>'
+  it 'displays desired fields' do
+    expect(rendered)
+      .to include('<span class="attribute-label h4">Keyword:</span>', 'keyword',
+                  '<span class="attribute-label h4">Resource Type:</span>', 'resource_type')
   end
 end

--- a/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
@@ -26,16 +26,23 @@ RSpec.describe 'hyrax/base/_form_metadata.html.erb', type: :view do
   describe 'form fields' do
     it 'has titles' do
       expect(page)
-        .to have_multivalued_field('title')
+        .to have_multivalued_field(:title)
         .on_model(work.class)
         .with_label 'Title'
     end
 
     it 'has keywords' do
       expect(page)
-        .to have_multivalued_field('keyword')
+        .to have_multivalued_field(:keyword)
         .on_model(work.class)
         .with_label 'Keyword'
+    end
+
+    it 'has resource_types' do
+      expect(page)
+        .to have_multivalued_field(:resource_type)
+        .on_model(work.class)
+        .with_label 'Resource type'
     end
   end
 end

--- a/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe 'hyrax/base/_form_metadata.html.erb', type: :view do
       expect(page)
         .to have_multivalued_field(:resource_type)
         .on_model(work.class)
-        .with_label 'Resource type'
+        .with_label('Resource type')
+        .and_options('article', 'capstone', 'dissertation', 'portfolio', 'thesis')
     end
   end
 end

--- a/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
@@ -26,16 +26,16 @@ RSpec.describe 'hyrax/base/_form_metadata.html.erb', type: :view do
   describe 'form fields' do
     it 'has titles' do
       expect(page)
-        .to have_multivalued_field('title',
-                                   model_class: work.class,
-                                   label:       'Title')
+        .to have_multivalued_field('title')
+        .on_model(work.class)
+        .with_label 'Title'
     end
 
     it 'has keywords' do
       expect(page)
-        .to have_multivalued_field('keyword',
-                                   model_class: work.class,
-                                   label:       'Keyword')
+        .to have_multivalued_field('keyword')
+        .on_model(work.class)
+        .with_label 'Keyword'
     end
   end
 end


### PR DESCRIPTION
Setup controlled vocabulary for resource types.

Test that the field is multi-valued, and test display in the search index view.

Remaining on #68 are:

  > When I look at the label for the field it should read "Document Type" (Hyrax default)

We need to confirm this and devise a testing strategy for ensuring labels are consistent across views (they are configured in multiple places).

>  When I look at the .ttl view I should be able to find the document types

Blocked pending #84.