### PR TITLE
Check presence of Metadata fields on show view

### DIFF
--- a/spec/support/matchers/have_show_field.rb
+++ b/spec/support/matchers/have_show_field.rb
@@ -1,0 +1,39 @@
+RSpec::Matchers.define :have_show_field do |name|
+  match do |rendered_view|
+    @displayed_fields = page.find_css("li.#{name}")
+
+    @exists         = !@displayed_fields.empty?
+    @extra_actual   = []
+    @extra_expected = []
+
+    if @values
+      displayed_values = @displayed_fields.map(&:text)
+      @extra_actual    = displayed_values - @values
+      @extra_expected  = @values - displayed_values
+    end
+
+    @label_exists = rendered_view.find(:xpath, "//th[contains(., \"#{label}\")]") if @label
+
+    @exists && @extra_actual.empty? && @extra_expected.empty? && (!@label || @label_exists)
+  end
+
+  chain :and_label,  :label
+  chain :with_label, :label
+
+  chain :and_values do |*values|
+    @values = values
+  end
+
+  chain :with_values do |*values|
+    @values = values
+  end
+
+  failure_message do |rendered_view|
+    msg = "expected #{rendered_view} to have field #{name}"
+    msg += " with values #{@values}"                               if     @values
+    msg += ' but no field was present.'                            unless @exists
+    msg += "\n\t#{@extra_actual} were found in the view."          unless @extra_actual.empty?
+    msg += "\n\t#{@extra_expected} were expected but not present." unless @extra_expected.empty?
+    msg
+  end
+end

--- a/spec/views/hyrax/base/_attribute_rows.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_attribute_rows.html.erb_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe 'hyrax/base/_attribute_rows.html.erb', type: :view do
+  subject(:page) do
+    render 'hyrax/base/attribute_rows', presenter: presenter
+    Capybara::Node::Simple.new(rendered)
+  end
+
+  let(:ability)       { double }
+  let(:presenter)     { Hyrax::WorkShowPresenter.new(solr_document, ability) }
+  let(:solr_document) { SolrDocument.new(work.to_solr) }
+  let(:work)          { FactoryGirl.build(:etd, **attributes) }
+
+  let(:attributes) { { keyword: ['moominland', 'moomintroll'] } }
+
+  it { is_expected.to have_show_field(:keyword).with_values(*attributes[:keyword]).and_label('Keyword') }
+end


### PR DESCRIPTION
Adds a `have_show_field` matcher for `Capybara::Node`s.

Checks presence of the `keyword` field.