### PR TITLE
Test .ttl serialization for presence of resource type

### DIFF
--- a/spec/presenters/hyrax/etd_presenter_spec.rb
+++ b/spec/presenters/hyrax/etd_presenter_spec.rb
@@ -4,13 +4,23 @@ RSpec.describe Hyrax::EtdPresenter, type: :presenter do
   subject(:presenter) { described_class.new(document, ability, request) }
   let(:ability)       { nil }
   let(:document)      { SolrDocument.new(etd.to_solr) }
-  let(:etd)           { FactoryGirl.create(:etd, id: 'moomin_id') }
+  let(:etd)           { FactoryGirl.create(:etd, id: 'moomin_id', **attributes) }
   let(:request)       { instance_double('Rack::Request', host: 'example.com') }
 
+  let(:attributes) do
+    { title:         ['Moomin Title'],
+      resource_type: ['letter from moominpapa'] }
+  end
+
   describe '#export_as_ttl' do
-    it 'has a title' do
-      expect(presenter.export_as_ttl)
-        .to include etd.class.properties['title'].predicate.to_base
+    let(:expected_fields) { [:title, :resource_type] }
+    let(:properties) { etd.class.properties }
+
+    it 'has expected predicates' do
+      predicates =
+        expected_fields.map { |f| properties[f.to_s].predicate.to_base }
+
+      expect(presenter.export_as_ttl).to include(*predicates)
     end
   end
 end


### PR DESCRIPTION
A resource type should appear in the .ttl views.

A refactor of the title spec is carried out to test all expected predicates with the `include` matcher.