### PR TITLE
Add Rights Note field

### DIFF
--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -3,6 +3,6 @@
 module Hyrax
   class EtdForm < Hyrax::Forms::WorkForm
     self.model_class = ::Etd
-    self.terms += [:resource_type]
+    self.terms += [:resource_type, :rights_note]
   end
 end

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -10,6 +10,8 @@ class Etd < ActiveFedora::Base
 
   self.human_readable_type = 'Etd'
 
+  apply_schema Schemas::CoreMetadata
+
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata

--- a/app/models/schemas/core_metadata.rb
+++ b/app/models/schemas/core_metadata.rb
@@ -1,0 +1,5 @@
+module Schemas
+  class CoreMetadata < ActiveTriples::Schema
+    property :rights_note, predicate: RDF::Vocab::DC11.rights
+  end
+end

--- a/spec/forms/hyrax/etd_form_spec.rb
+++ b/spec/forms/hyrax/etd_form_spec.rb
@@ -11,4 +11,8 @@ RSpec.describe Hyrax::EtdForm do
       expect(form.required_fields).to include :title
     end
   end
+
+  describe '#terms' do
+    it { expect(form.terms).to include :rights_note }
+  end
 end

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Etd do
   subject(:etd) { FactoryGirl.build(:etd) }
 
   it_behaves_like 'a model with basic metadata'
+  it_behaves_like 'a model with ohsu core metadata'
 
   describe 'an attached pdf' do
     let(:actor)  { Hyrax::Actors::FileSetActor.new(FileSet.create, user) }

--- a/spec/presenters/hyrax/etd_presenter_spec.rb
+++ b/spec/presenters/hyrax/etd_presenter_spec.rb
@@ -11,12 +11,14 @@ RSpec.describe Hyrax::EtdPresenter, type: :presenter do
     { title:         ['Moomin Title'],
       creator:       ['Tove Jansson'],
       resource_type: ['letter from moominpapa'],
-      source:        ['Too-Ticky'] }
+      source:        ['Too-Ticky'],
+      rights_note:   ['For the exclusive viewing of Little My.',
+                      'Moomin: do not read this.'] }
   end
 
   describe '#export_as_ttl' do
-    let(:expected_fields) { [:title, :creator, :resource_type, :source] }
-    let(:properties) { etd.class.properties }
+    let(:expected_fields) { [:creator, :title, :resource_type, :rights_note, :source] }
+    let(:properties)      { etd.class.properties }
 
     it 'has expected predicates' do
       predicates =

--- a/spec/support/shared_examples/core_metadata.rb
+++ b/spec/support/shared_examples/core_metadata.rb
@@ -1,0 +1,5 @@
+RSpec.shared_examples 'a model with ohsu core metadata' do
+  subject(:model) { described_class.new }
+
+  it { is_expected.to have_editable_property(:rights_note, RDF::Vocab::DC11.rights) }
+end

--- a/spec/views/catalog/_index_list_default.html.erb_spec.rb
+++ b/spec/views/catalog/_index_list_default.html.erb_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe 'catalog/_index_list_default', type: :view do
   let(:attributes) do
     { creator:       ['Tove Jansson'],
       keyword:       ['moomin', 'snorkmaiden'],
-      resource_type: ['Moomin'],
-      source:        ['Too-Ticky'] }
+      resource_type: ['letter from moominpapa'],
+      source:        ['Too-Ticky'],
+      rights_note:   ['for moomin access only'] }
   end
 
   let!(:document)  { SolrDocument.new(etd.to_solr) }
@@ -26,7 +27,7 @@ RSpec.describe 'catalog/_index_list_default', type: :view do
 
   # title appears in a different partial, not in the metadata listing
   it 'does not display undesired fields' do
-    is_expected.not_to list_index_fields('Title', 'Source')
+    is_expected.not_to list_index_fields('Title', 'Source', 'Rights Note')
   end
 
   it 'displays desired fields' do

--- a/spec/views/hyrax/base/_attribute_rows.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_attribute_rows.html.erb_spec.rb
@@ -12,12 +12,15 @@ RSpec.describe 'hyrax/base/_attribute_rows.html.erb', type: :view do
   let(:work)          { FactoryGirl.build(:etd, **attributes) }
 
   let(:attributes) do
-    { creator: ['Tove Jansson', 'Lars Jansson'],
-      keyword: ['moominland', 'moomintroll'],
-      source:  ['Too-Ticky'] }
+    { creator:     ['Tove Jansson', 'Lars Jansson'],
+      keyword:     ['moominland', 'moomintroll'],
+      source:      ['Too-Ticky'],
+      rights_note: ['For the exclusive viewing of Little My.',
+                    'Moomin: do not read this.'] }
   end
 
   it { is_expected.to have_show_field(:creator).with_values(*attributes[:creator]).and_label('Creator') }
   it { is_expected.to have_show_field(:keyword).with_values(*attributes[:keyword]).and_label('Keyword') }
   it { is_expected.to have_show_field(:source).with_values(*attributes[:source]).and_label('Source') }
+  it { is_expected.not_to have_show_field(:rights_note) }
 end

--- a/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
@@ -53,6 +53,13 @@ RSpec.describe 'hyrax/base/_form_metadata.html.erb', type: :view do
         .and_options('article', 'capstone', 'dissertation', 'portfolio', 'thesis')
     end
 
+    it 'has rights notes' do
+      expect(page)
+        .to have_multivalued_field(:rights_note)
+        .on_model(work.class)
+        .with_label('Rights note')
+    end
+
     it 'has sources' do
       expect(page)
         .to have_multivalued_field(:source)


### PR DESCRIPTION
This adds a `Schema::CoreMetadata` class to hold general OHSU metadata and adds the `rights_note` to it. `Schema::CoreMetadata`  is then included in `Etd`.

The rights note is added to the `EtdForm`, and various tests are added to ensure correct behavior.

Closes #59.