### PR TITLE
Single value support for `have_editable_property` matcher

### DIFF
--- a/spec/support/matchers/have_editable_property.rb
+++ b/spec/support/matchers/have_editable_property.rb
@@ -1,11 +1,25 @@
 RSpec::Matchers.define :have_editable_property do |property, predicate|
   match do |model|
+    # @todo deprecate two-argument call style in favor chaining
+    predicate ||= chain_predicate
+    predicate = RDF::URI.intern(predicate)
+
     values = ['Comet in Moominland', 'Moomin Midwinter']
     values = values.first if @single
+
+    config = model.class.properties.fetch(property.to_s) do
+      @missing_property = true
+      return false
+    end
 
     expect { model.public_send("#{property}=", values) }
       .to change { Array(model.public_send(property)) }
       .to contain_exactly(*values)
+
+    return true unless predicate
+
+    @actual_predicate = config.predicate
+    return false unless @actual_predicate == predicate
 
     Array(values).each do |value|
       expect(model.resource.statements)
@@ -15,7 +29,19 @@ RSpec::Matchers.define :have_editable_property do |property, predicate|
     true
   end
 
+  chain :with_predicate, :chain_predicate
+
   chain :as_single_valued do
     @single = true
+  end
+
+  failure_message do |model|
+    msg = "expected #{model.class} to have an editable property `#{property}`"
+    msg += " with predicate #{predicate.to_base}." if predicate
+
+    return msg + "\n\tNo property for `#{property}` was found." if @missing_property
+
+    msg += "\n\tThe configured predicate was #{@actual_predicate.to_base}" unless @actual_predicate == predicate
+    msg
   end
 end

--- a/spec/support/matchers/have_editable_property.rb
+++ b/spec/support/matchers/have_editable_property.rb
@@ -1,18 +1,21 @@
 RSpec::Matchers.define :have_editable_property do |property, predicate|
   match do |model|
     values = ['Comet in Moominland', 'Moomin Midwinter']
+    values = values.first if @single
 
     expect { model.public_send("#{property}=", values) }
-      .to change { model.public_send(property).to_a }
+      .to change { Array(model.public_send(property)) }
       .to contain_exactly(*values)
 
-    expect(model.resource.statements)
-      .to include(RDF::Statement(model.rdf_subject,
-                                 predicate,
-                                 'Comet in Moominland'),
-                  RDF::Statement(model.rdf_subject,
-                                 predicate,
-                                 'Moomin Midwinter'))
+    Array(values).each do |value|
+      expect(model.resource.statements)
+        .to include(RDF::Statement(model.rdf_subject, predicate, value))
+    end
+
     true
+  end
+
+  chain :as_single_valued do
+    @single = true
   end
 end

--- a/spec/support/matchers/have_multivalued_field.rb
+++ b/spec/support/matchers/have_multivalued_field.rb
@@ -1,4 +1,4 @@
-RSpec::Matchers.define :have_multivalued_field do |name|
+RSpec::Matchers.define :have_form_field do |name|
   match do |rendered_form|
     raise 'Specify a model with `.on_model(Klass)` to use this matcher.' unless
       model_class
@@ -6,7 +6,7 @@ RSpec::Matchers.define :have_multivalued_field do |name|
     @selector = "#{model_class.to_s.downcase}_#{name}"
     @field    = rendered_form.find_css("##{@selector}").first
 
-    expect(@field).not_to be_nil
+    return false unless @field
 
     @multiple = case @field.node_name
                 when 'input'
@@ -29,12 +29,19 @@ RSpec::Matchers.define :have_multivalued_field do |name|
       @options_missing = (@options - @option_values)
     end
 
-    @field && @multiple && (!label || @label_match) && @options_missing.empty?
+    @field &&
+      (@multiple || @single) &&
+      (!label || @label_match) &&
+      @options_missing.empty?
   end
 
   chain :on_model,   :model_class
   chain :and_label,  :label
   chain :with_label, :label
+
+  chain :as_single_valued do
+    @single = true
+  end
 
   chain :and_options do |*options|
     @options = options
@@ -57,3 +64,5 @@ RSpec::Matchers.define :have_multivalued_field do |name|
     msg
   end
 end
+
+RSpec::Matchers.alias_matcher :have_multivalued_field, :have_form_field

--- a/spec/support/matchers/have_multivalued_field.rb
+++ b/spec/support/matchers/have_multivalued_field.rb
@@ -30,7 +30,7 @@ RSpec::Matchers.define :have_form_field do |name|
     end
 
     @field &&
-      (@multiple || @single) &&
+      (@single ^ @multiple) &&
       (!label || @label_match) &&
       @options_missing.empty?
   end
@@ -52,12 +52,14 @@ RSpec::Matchers.define :have_form_field do |name|
   end
 
   failure_message do |rendered_form|
-    msg = "expected #{rendered_form} to have multivlaued field #{name}"
+    msg = "expected #{rendered_form} to have field #{name}"
+    msg += ' as ' + (@single ? 'single valued' : 'multivalued')
     msg += " for class #{model_class}"          if     model_class
     msg += " with label #{label}"               if     label
     msg += " with options #{@options}"          if     @options
     msg += "\n\tNo field found: #{@selector}."  unless @field
-    msg += "\n\tField not multivalued."         unless @multiple
+    msg += "\n\tField not multivalued."         unless @single || @multiple
+    msg += "\n\tField not single valued."       if     @single && @multiple
     msg += "\n\tLabel was #{@label_text}."      unless @label_match
     msg += "\n\tOptions were #{@option_values}" unless @options_missing.empty?
     msg += "\n\t#{@field}."                     if     @field

--- a/spec/support/shared_examples/hyrax_basic_metadata.rb
+++ b/spec/support/shared_examples/hyrax_basic_metadata.rb
@@ -1,9 +1,26 @@
 RSpec.shared_examples 'a model with core metadata' do
   subject(:model) { described_class.new }
 
-  describe '#date_modified'
-  describe '#date_uploaded'
-  describe '#depositor'
+  it do
+    is_expected
+      .to have_editable_property(:date_modified)
+      .with_predicate(RDF::Vocab::DC.modified)
+      .as_single_valued
+  end
+
+  it do
+    is_expected
+      .to have_editable_property(:date_uploaded)
+      .with_predicate(RDF::Vocab::DC.dateSubmitted)
+      .as_single_valued
+  end
+
+  it do
+    is_expected
+      .to have_editable_property(:depositor)
+      .with_predicate(RDF::Vocab::MARCRelators.dpt)
+      .as_single_valued
+  end
 
   describe '#first_title' do
     it 'is nil when empty' do
@@ -25,7 +42,27 @@ RSpec.shared_examples 'a model with basic metadata' do
 
   it_behaves_like 'a model with core metadata'
 
-  it 'has singular properties' # label, relative_path, import_url
+  it do
+    is_expected
+      .to have_editable_property(:label)
+      .with_predicate('info:fedora/fedora-system:def/model#downloadFilename')
+      .as_single_valued
+  end
+
+  it do
+    is_expected
+      .to have_editable_property(:relative_path)
+      .with_predicate('http://scholarsphere.psu.edu/ns#relativePath')
+      .as_single_valued
+  end
+
+  it do
+    is_expected
+      .to have_editable_property(:import_url)
+      .with_predicate('http://scholarsphere.psu.edu/ns#importUrl')
+      .as_single_valued
+  end
+
   it { is_expected.to have_editable_property(:bibliographic_citation, RDF::Vocab::DC.bibliographicCitation) }
   it { is_expected.to have_editable_property(:contributor, RDF::Vocab::DC11.contributor) }
   it { is_expected.to have_editable_property(:creator, RDF::Vocab::DC11.creator) }


### PR DESCRIPTION
The editable property and form field matchers are updated to support single values. You can now use `.as_single_valued` with either to assert single value.

The editable property matcher is also extended to be more flexible and offer better diagnostic support in the form of failure messages.

Testing for Hyrax's `CoreMetadata` and `BasicMetadata` is improved with support from the new matchers.