### PR TITLE
Use "Document Type" as the label for `resource_type`

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -77,7 +77,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("date_uploaded", :stored_sortable, type: :date), itemprop: 'datePublished', helper_method: :human_readable_date
     config.add_index_field solr_name("date_modified", :stored_sortable, type: :date), itemprop: 'dateModified', helper_method: :human_readable_date
     config.add_index_field solr_name("date_created", :stored_searchable), itemprop: 'dateCreated'
-    config.add_index_field solr_name("resource_type", :stored_searchable), label: "Resource Type", link_to_search: solr_name("resource_type", :facetable)
+    config.add_index_field solr_name("resource_type", :stored_searchable), label: "Document Type", link_to_search: solr_name("resource_type", :facetable)
     config.add_index_field solr_name("file_format", :stored_searchable), link_to_search: solr_name("file_format", :facetable)
     config.add_index_field solr_name("identifier", :stored_searchable), helper_method: :index_field_link, field_name: 'identifier'
     config.add_index_field solr_name("embargo_release_date", :stored_sortable, type: :date), label: "Embargo release date", helper_method: :human_readable_date

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,3 +1,7 @@
 en:
   blacklight:
     application_name: 'Blacklight'
+    search:
+      fields:
+        show:
+          resource_type: "Document type"

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -1,0 +1,5 @@
+en:
+  simple_form:
+    labels:
+      defaults:
+        resource_type: "Document type"

--- a/spec/views/catalog/_index_list_default.html.erb_spec.rb
+++ b/spec/views/catalog/_index_list_default.html.erb_spec.rb
@@ -32,6 +32,6 @@ RSpec.describe 'catalog/_index_list_default', type: :view do
   end
 
   it 'displays desired fields' do
-    is_expected.to list_index_fields('Creator', 'Keyword', 'Resource Type', 'Subject')
+    is_expected.to list_index_fields('Creator', 'Keyword', 'Document Type', 'Subject')
   end
 end

--- a/spec/views/hyrax/base/_attribute_rows.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_attribute_rows.html.erb_spec.rb
@@ -12,17 +12,19 @@ RSpec.describe 'hyrax/base/_attribute_rows.html.erb', type: :view do
   let(:work)          { FactoryGirl.build(:etd, **attributes) }
 
   let(:attributes) do
-    { creator:     ['Tove Jansson', 'Lars Jansson'],
-      keyword:     ['moominland', 'moomintroll'],
-      source:      ['Too-Ticky'],
-      rights_note: ['For the exclusive viewing of Little My.',
-                    'Moomin: do not read this.'],
-      subject:     ['Moomins', 'Snorks'] }
+    { creator:       ['Tove Jansson', 'Lars Jansson'],
+      keyword:       ['moominland', 'moomintroll'],
+      source:        ['Too-Ticky'],
+      rights_note:   ['For the exclusive viewing of Little My.',
+                      'Moomin: do not read this.'],
+      subject:       ['Moomins', 'Snorks'],
+      resource_type: ['letter from moominpapa'] }
   end
 
   it { is_expected.to have_show_field(:creator).with_values(*attributes[:creator]).and_label('Creator') }
   it { is_expected.to have_show_field(:keyword).with_values(*attributes[:keyword]).and_label('Keyword') }
   it { is_expected.to have_show_field(:source).with_values(*attributes[:source]).and_label('Source') }
-  it { is_expected.not_to have_show_field(:rights_note) }
   it { is_expected.to have_show_field(:subject).with_values(*attributes[:subject]).and_label('Subject') }
+  it { is_expected.to have_show_field(:resource_type).with_values(*attributes[:resource_type]).and_label('Document type') }
+  it { is_expected.not_to have_show_field(:rights_note) }
 end

--- a/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'hyrax/base/_form_metadata.html.erb', type: :view do
       expect(page)
         .to have_multivalued_field(:resource_type)
         .on_model(work.class)
-        .with_label('Resource type')
+        .with_label('Document type')
         .and_options('article', 'capstone', 'dissertation', 'portfolio', 'thesis')
     end
 


### PR DESCRIPTION
This is a first hack at custom labels for fields. Facet labels are still untested.

Closes #68. (Other parts of that ticket have been addressed in previous PRs)