### PR TITLE
Test Source term on ETDs

### DIFF
--- a/spec/presenters/hyrax/etd_presenter_spec.rb
+++ b/spec/presenters/hyrax/etd_presenter_spec.rb
@@ -10,11 +10,12 @@ RSpec.describe Hyrax::EtdPresenter, type: :presenter do
   let(:attributes) do
     { title:         ['Moomin Title'],
       creator:       ['Tove Jansson'],
-      resource_type: ['letter from moominpapa'] }
+      resource_type: ['letter from moominpapa'],
+      source:        ['Too-Ticky'] }
   end
 
   describe '#export_as_ttl' do
-    let(:expected_fields) { [:title, :creator, :resource_type] }
+    let(:expected_fields) { [:title, :creator, :resource_type, :source] }
     let(:properties) { etd.class.properties }
 
     it 'has expected predicates' do

--- a/spec/support/matchers/list_index_field.rb
+++ b/spec/support/matchers/list_index_field.rb
@@ -1,0 +1,30 @@
+RSpec::Matchers.define :list_index_fields do |*names|
+  match do |rendered_view|
+    @missing_names = decorated_names(names) - labels_for(rendered_view)
+    @missing_names.empty?
+  end
+
+  match_when_negated do |rendered_view|
+    @missing_names = decorated_names(names) - labels_for(rendered_view)
+    @not_missing = (decorated_names(names) - @missing_names)
+    @not_missing.empty?
+  end
+
+  def decorated_names(names)
+    names.map { |name| name.end_with?(':') ? name : name + ':' }
+  end
+
+  def labels_for(view)
+    view.find('.metadata').all('.attribute-label').map(&:text)
+  end
+
+  failure_message do |rendered_view|
+    msg = "expected #{rendered_view} to list index fields #{names}"
+    msg + "\n\tthe fields #{@missing_names} were not present."
+  end
+
+  failure_message_when_negated do |rendered_view|
+    msg = "expected #{rendered_view} not to list index fields #{names}"
+    msg + "\n\tbut #{@not_missing} were present."
+  end
+end

--- a/spec/views/catalog/_index_list_default.html.erb_spec.rb
+++ b/spec/views/catalog/_index_list_default.html.erb_spec.rb
@@ -1,10 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe 'catalog/_index_list_default', type: :view do
+  subject(:page) { Capybara::Node::Simple.new(rendered) }
+
   let(:attributes) do
     { creator:       ['Tove Jansson'],
       keyword:       ['moomin', 'snorkmaiden'],
-      resource_type: ['Moomin'] }
+      resource_type: ['Moomin'],
+      source:        ['Too-Ticky'] }
   end
 
   let!(:document)  { SolrDocument.new(etd.to_solr) }
@@ -23,13 +26,10 @@ RSpec.describe 'catalog/_index_list_default', type: :view do
 
   # title appears in a different partial, not in the metadata listing
   it 'does not display undesired fields' do
-    expect(rendered).not_to include 'title'
+    is_expected.not_to list_index_fields('Title', 'Source')
   end
 
   it 'displays desired fields' do
-    expect(rendered)
-      .to include('<span class="attribute-label h4">Creator:</span>', 'creator',
-                  '<span class="attribute-label h4">Keyword:</span>', 'keyword',
-                  '<span class="attribute-label h4">Resource Type:</span>', 'resource_type')
+    is_expected.to list_index_fields('Creator', 'Keyword', 'Resource Type')
   end
 end

--- a/spec/views/hyrax/base/_attribute_rows.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_attribute_rows.html.erb_spec.rb
@@ -13,9 +13,11 @@ RSpec.describe 'hyrax/base/_attribute_rows.html.erb', type: :view do
 
   let(:attributes) do
     { creator: ['Tove Jansson', 'Lars Jansson'],
-      keyword: ['moominland', 'moomintroll'] }
+      keyword: ['moominland', 'moomintroll'],
+      source:  ['Too-Ticky'] }
   end
 
   it { is_expected.to have_show_field(:creator).with_values(*attributes[:creator]).and_label('Creator') }
   it { is_expected.to have_show_field(:keyword).with_values(*attributes[:keyword]).and_label('Keyword') }
+  it { is_expected.to have_show_field(:source).with_values(*attributes[:source]).and_label('Source') }
 end

--- a/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
@@ -52,5 +52,12 @@ RSpec.describe 'hyrax/base/_form_metadata.html.erb', type: :view do
         .with_label('Resource type')
         .and_options('article', 'capstone', 'dissertation', 'portfolio', 'thesis')
     end
+
+    it 'has sources' do
+      expect(page)
+        .to have_multivalued_field(:source)
+        .on_model(work.class)
+        .with_label 'Source'
+    end
   end
 end


### PR DESCRIPTION
In addition to testing the source term behavior, the expectations for index fields are moved to a matcher.

Closes #74.