### PR TITLE
Use a factory for populated ETDs to DRY up specs

### DIFF
--- a/spec/factories/etds.rb
+++ b/spec/factories/etds.rb
@@ -22,5 +22,21 @@ FactoryGirl.define do
     factory :public_etd do
       visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     end
+
+    factory :moomins_thesis do
+      creator       ['Moomin', 'Hemulen']
+      date_label    ['Winter in Moomin Valley']
+      degree        ['M.Phil.']
+      identifier    ['Moomin_123']
+      institution   ['Moomin Valley Community College']
+      keyword       ['moomin', 'snork', 'hattifattener']
+      language      ['Finnish', 'Swedish']
+      orcid_id      ['0000-0001-2345-6789', '0000-0002-1825-0097']
+      source        ['Too-Ticky', 'Snufkin']
+      subject       ['Moomins', 'Snorks']
+      rights_note   ['For the exclusive viewing of Little My.',
+                     'Moomin: do not read this.']
+      resource_type ['thesis']
+    end
   end
 end

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -30,17 +30,19 @@ RSpec.feature 'Create a Etd', js: false do
     end
 
     scenario 'editing' do
-      etd = FactoryGirl.create(:etd, user: user)
+      etd = FactoryGirl.create(:moomins_thesis, user: user)
 
       visit "concern/etds/#{etd.id}"
       click_link 'Edit'
 
-      new_title = 'Finn Family Moomintroll'
+      new_title   = 'Finn Family Moomintroll'
+      new_keyword = 'moomin'
 
-      fill_in 'Title', with: new_title
+      fill_in 'Title',   with: new_title
+      fill_in 'Keyword', with: new_keyword
       find('#with_files_submit').click
 
-      expect(page).to have_content new_title
+      expect(page).to have_content(new_title, new_keyword)
     end
   end
 end

--- a/spec/presenters/hyrax/etd_presenter_spec.rb
+++ b/spec/presenters/hyrax/etd_presenter_spec.rb
@@ -4,24 +4,8 @@ RSpec.describe Hyrax::EtdPresenter, type: :presenter do
   subject(:presenter) { described_class.new(document, ability, request) }
   let(:ability)       { nil }
   let(:document)      { SolrDocument.new(etd.to_solr) }
-  let(:etd)           { FactoryGirl.create(:etd, id: 'moomin_id', **attributes) }
+  let(:etd)           { FactoryGirl.create(:moomins_thesis, id: 'moomin_id') }
   let(:request)       { instance_double('Rack::Request', host: 'example.com') }
-
-  let(:attributes) do
-    { title:         ['Moomin Title'],
-      creator:       ['Tove Jansson'],
-      degree:        ['M.Phil.'],
-      identifier:    ['Moomin_123'],
-      institution:   ['Moomin Valley Historical Society'],
-      orcid_id:      ['0000-0001-2345-6789'],
-      date_label:    ['Winter in Moomin Valley'],
-      language:      ['en-US'],
-      resource_type: ['letter from moominpapa'],
-      source:        ['Too-Ticky'],
-      rights_note:   ['For the exclusive viewing of Little My.',
-                      'Moomin: do not read this.'],
-      subject:       ['Moomintrolls', 'Snorks'] }
-  end
 
   describe '#export_as_ttl' do
     let(:expected_fields) do

--- a/spec/views/catalog/_index_list_default.html.erb_spec.rb
+++ b/spec/views/catalog/_index_list_default.html.erb_spec.rb
@@ -1,23 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe 'catalog/_index_list_default', type: :view do
-  subject(:page) { Capybara::Node::Simple.new(rendered) }
-
-  let(:attributes) do
-    { creator:       ['Tove Jansson'],
-      degree:        ['M.Phil.'],
-      identifier:    ['Moomin_123'],
-      date_label:    ['Winter in Moomin Valley'],
-      keyword:       ['moomin', 'snorkmaiden'],
-      resource_type: ['letter from moominpapa'],
-      source:        ['Too-Ticky'],
-      rights_note:   ['for moomin access only'],
-      subject:       ['Moomins', 'Snorks'],
-      language:      ['en-US'] }
-  end
-
+  subject(:page)   { Capybara::Node::Simple.new(rendered) }
   let!(:document)  { SolrDocument.new(etd.to_solr) }
-  let!(:etd)       { FactoryGirl.build(:etd, **attributes) }
+  let!(:etd)       { FactoryGirl.build(:moomins_thesis) }
   let!(:presenter) { instance_double('Blacklight::IndexPresenter') }
 
   before do

--- a/spec/views/hyrax/base/_attribute_rows.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_attribute_rows.html.erb_spec.rb
@@ -9,32 +9,18 @@ RSpec.describe 'hyrax/base/_attribute_rows.html.erb', type: :view do
   let(:ability)       { double }
   let(:presenter)     { Hyrax::EtdPresenter.new(solr_document, ability) }
   let(:solr_document) { SolrDocument.new(work.to_solr) }
-  let(:work)          { FactoryGirl.build(:etd, **attributes) }
+  let(:work)          { FactoryGirl.build(:moomins_thesis) }
 
-  let(:attributes) do
-    { creator:       ['Tove Jansson', 'Lars Jansson'],
-      date_label:    ['Winter in Moomin Valley'],
-      degree:        ['M.Phil.'],
-      keyword:       ['moominland', 'moomintroll'],
-      institution:   ['Moomin Valley Historical Society'],
-      orcid_id:      ['0000-0001-2345-6789'],
-      source:        ['Too-Ticky'],
-      rights_note:   ['For the exclusive viewing of Little My.',
-                      'Moomin: do not read this.'],
-      subject:       ['Moomins', 'Snorks'],
-      language: ['en-US'],
-      resource_type: ['letter from moominpapa'] }
-  end
+  it { is_expected.to have_show_field(:creator).with_values(*work.creator).and_label('Creator') }
+  it { is_expected.to have_show_field(:date_label).with_values(*work.date_label).and_label('Date label') }
+  it { is_expected.to have_show_field(:degree).with_values(*work.degree).and_label('Degree Name') }
+  it { is_expected.to have_show_field(:institution).with_values(*work.institution).and_label('Institution') }
+  it { is_expected.to have_show_field(:keyword).with_values(*work.keyword).and_label('Keyword') }
+  it { is_expected.to have_show_field(:language).with_values(*work.language).and_label('Language') }
+  it { is_expected.to have_show_field(:orcid_id).with_values(*work.orcid_id).and_label('ORCID') }
+  it { is_expected.to have_show_field(:resource_type).with_values(*work.resource_type).and_label('Document type') }
+  it { is_expected.to have_show_field(:source).with_values(*work.source).and_label('Source') }
+  it { is_expected.to have_show_field(:subject).with_values(*work.subject).and_label('Subject') }
 
-  it { is_expected.to have_show_field(:creator).with_values(*attributes[:creator]).and_label('Creator') }
-  it { is_expected.to have_show_field(:date_label).with_values(*attributes[:date_label]).and_label('Date label') }
-  it { is_expected.to have_show_field(:degree).with_values(*attributes[:degree]).and_label('Degree Name') }
-  it { is_expected.to have_show_field(:institution).with_values(*attributes[:institution]).and_label('Institution') }
-  it { is_expected.to have_show_field(:keyword).with_values(*attributes[:keyword]).and_label('Keyword') }
-  it { is_expected.to have_show_field(:orcid_id).with_values(*attributes[:orcid_id]).and_label('ORCID') }
-  it { is_expected.to have_show_field(:source).with_values(*attributes[:source]).and_label('Source') }
-  it { is_expected.to have_show_field(:subject).with_values(*attributes[:subject]).and_label('Subject') }
-  it { is_expected.to have_show_field(:resource_type).with_values(*attributes[:resource_type]).and_label('Document type') }
   it { is_expected.not_to have_show_field(:rights_note) }
-  it { is_expected.to have_show_field(:language).with_values(*attributes[:language]).and_label('Language') }
 end


### PR DESCRIPTION
We were assigning attributes in many places, it's better to use a factory instead.