### PR TITLE
Put identifier registration architecture in place 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,8 @@ gem 'rsolr', '>= 1.0'
 group :development, :test do
   gem 'database_cleaner'
   gem 'fcrepo_wrapper'
-  gem 'hyrax-spec', '~> 0.1.0'
+  # gem 'hyrax-spec', '~> 0.1.0'
+  gem 'hyrax-spec', github: 'curationexperts/hyrax-spec', branch: 'master'
   gem 'rspec-rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/curationexperts/hyrax-spec.git
+  revision: ac64c3552a3889afa1189acdd88d2662f379fbb1
+  branch: master
+  specs:
+    hyrax-spec (0.1.0)
+      rspec (~> 3.6)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -254,18 +262,18 @@ GEM
       railties (>= 3.2, < 5.2)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    google-api-client (0.13.6)
+    google-api-client (0.17.1)
       addressable (~> 2.5, >= 2.5.1)
-      googleauth (~> 0.5)
+      googleauth (>= 0.5, < 0.7.0)
       httpclient (>= 2.8.1, < 3.0)
       mime-types (~> 3.0)
       representable (~> 3.0)
       retriable (>= 2.0, < 4.0)
-    google_drive (2.1.6)
-      google-api-client (>= 0.11.0, < 0.14.0)
+    google_drive (2.1.3)
+      google-api-client (>= 0.11.0, < 1.0.0)
       googleauth (>= 0.5.0, < 1.0.0)
       nokogiri (>= 1.5.3, < 2.0.0)
-    googleauth (0.6.1)
+    googleauth (0.6.2)
       faraday (~> 0.12)
       jwt (>= 1.4, < 3.0)
       logging (~> 2.0)
@@ -370,8 +378,6 @@ GEM
       select2-rails (~> 3.5)
       signet
       tinymce-rails (~> 4.1)
-    hyrax-spec (0.1.0)
-      rspec (~> 3.6)
     i18n (0.9.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
@@ -756,7 +762,7 @@ GEM
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
-    tinymce-rails (4.7.1)
+    tinymce-rails (4.7.2)
       railties (>= 3.1.1)
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
@@ -806,7 +812,7 @@ DEPENDENCIES
   fcrepo_wrapper
   hydra-role-management
   hyrax (~> 2.0.0)
-  hyrax-spec (~> 0.1.0)
+  hyrax-spec!
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)
@@ -830,4 +836,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/app/actors/hyrax/actors/datacite_actor.rb
+++ b/app/actors/hyrax/actors/datacite_actor.rb
@@ -1,0 +1,29 @@
+module Hyrax
+  module Actors
+    ##
+    # An actor that registers a DOI with DataCite.
+    #
+    # @example use in middleware
+    #   stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
+    #     # middleware.use OtherMiddleware
+    #     middleware.use Hyrax::Actors::DataciteActor
+    #     # middleware.use MoreMiddleware
+    #   end
+    #
+    #   env = Hyrax::Actors::Environment.new(object, ability, attributes)
+    #   last_actor = Hyrax::Actors::Terminator.new
+    #   stack.build(last_actor).create(env)
+    #
+    # @see https://www.datacite.org/
+    class DataciteActor < AbstractActor
+      ##
+      # @return [Boolean]
+      #
+      # @see Hyrax::Actors::AbstractActor
+      def create(env)
+        DataciteRegisterJob.perform_later(env.curation_concern) &&
+          next_actor.create(env)
+      end
+    end
+  end
+end

--- a/app/jobs/datacite_register_job.rb
+++ b/app/jobs/datacite_register_job.rb
@@ -1,0 +1,11 @@
+class DataciteRegisterJob < ApplicationJob
+  queue_as :id_service
+
+  ##
+  # @param model [ActiveFedora::Base]
+  def perform(model)
+    Mahonia::IdentifierDispatcher
+      .for(:datacite)
+      .assign_for!(object: model)
+  end
+end

--- a/app/lib/mahonia/datacite_registrar.rb
+++ b/app/lib/mahonia/datacite_registrar.rb
@@ -1,0 +1,9 @@
+module Mahonia
+  class DataciteRegistrar < IdentifierRegistrar
+    IdentifierRecord = Struct.new(:identifier)
+
+    def register!(*)
+      IdentifierRecord.new('moomin')
+    end
+  end
+end

--- a/app/lib/mahonia/identifier_dispatcher.rb
+++ b/app/lib/mahonia/identifier_dispatcher.rb
@@ -1,0 +1,56 @@
+module Mahonia
+  class IdentifierDispatcher
+    ##
+    # @!attribute [rw] registrar
+    #   @return [IdentifierRegistrar]
+    attr_accessor :registrar
+
+    ##
+    # @param registrar [IdentifierRegistrar]
+    def initialize(registrar:)
+      @registrar = registrar
+    end
+
+    class << self
+      ##
+      # @param type [Symbol]
+      #
+      # @return [IdentifierDispatcher] a dispatcher with an registrar for the
+      #   given type
+      # @see IdentifierRegistrar.for
+      def for(type)
+        new(registrar: Mahonia::IdentifierRegistrar.for(type))
+      end
+    end
+
+    ##
+    # Assigns an identifier to the object.
+    #
+    # This involves two steps:
+    #   - Registering the identifier with the registrar service via `registrar`.
+    #   - Storing the new identifier on the object, in the provided `attribute`.
+    #
+    # @note the attribute for identifier storage must be multi-valued, and will
+    #  be overwritten during assignment.
+    #
+    # @param attribute [Symbol] the attribute in which to store the identifier.
+    #   This attribute will be overwritten during assignment.
+    # @param object    [AciveFedora::Base] the object to assign an identifier.
+    #
+    # @return [AciveFedora::Base] object
+    def assign_for(object:, attribute: :identifier)
+      record = registrar.register!(object: object)
+      object.public_send("#{attribute}=".to_sym, [record.identifier])
+      object
+    end
+
+    ##
+    # Assigns an identifier and saves the object.
+    #
+    # @see #assign_for
+    def assign_for!(object:, attribute: :identifier)
+      assign_for(object: object, attribute: attribute).save!
+      object
+    end
+  end
+end

--- a/app/lib/mahonia/identifier_registrar.rb
+++ b/app/lib/mahonia/identifier_registrar.rb
@@ -1,0 +1,28 @@
+module Mahonia
+  class IdentifierRegistrar
+    class << self
+      # @param type [Symbol]
+      #
+      # @return [IdentifierRegistrar] a  registrar for the given type
+      def for(type)
+        case type
+        when :datacite
+          'Mahonia::DataciteRegistrar'.constantize.new
+        else
+          raise ArgumentError, "IdentifierRegistrar not found to handle #{type}"
+        end
+      end
+    end
+
+    ##
+    # @abstract
+    #
+    # @param object [#id]
+    #
+    # @return [#identifier]
+    # @raise [NotImplementedError] when the method is abstract
+    def register!(*)
+      raise NotImplementedError
+    end
+  end
+end

--- a/spec/actors/hyrax/actors/datacite_actor_spec.rb
+++ b/spec/actors/hyrax/actors/datacite_actor_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Hyrax::Actors::DataciteActor do
+  subject(:actor)  { described_class.new(next_actor) }
+  let(:ability)    { Ability.new(user) }
+  let(:env)        { Hyrax::Actors::Environment.new(object, ability, {}) }
+  let(:next_actor) { Hyrax::Actors::Terminator.new }
+  let(:object)     { FactoryBot.create(:etd) }
+  let(:user)       { FactoryBot.build(:user) }
+
+  it { expect(described_class).to act.and_succeed }
+
+  describe '#create' do
+    before { ActiveJob::Base.queue_adapter = :test }
+
+    it 'enqueues a job' do
+      expect { actor.create(env) }
+        .to have_enqueued_job(DataciteRegisterJob)
+        .with(object)
+        .on_queue('id_service')
+    end
+  end
+end

--- a/spec/jobs/datacite_register_job_spec.rb
+++ b/spec/jobs/datacite_register_job_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe DataciteRegisterJob, type: :job do
+  let(:object) { create(:etd) }
+
+  describe '.perform_later' do
+    before { ActiveJob::Base.queue_adapter = :test }
+
+    it 'enqueues the job' do
+      expect { described_class.perform_later(object) }
+        .to enqueue_job(described_class)
+        .with(object)
+        .on_queue('id_service')
+    end
+  end
+
+  describe '.perform_now' do
+    it 'adds an id to the object' do
+      expect { described_class.perform_now(object) }
+        .to change { object.identifier.to_a }
+        .to contain_exactly 'moomin'
+    end
+  end
+end

--- a/spec/lib/mahonia/datacite_registrar_spec.rb
+++ b/spec/lib/mahonia/datacite_registrar_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Mahonia::DataciteRegistrar do
+  describe '#register!' do
+    it 'registers a datacite id'
+  end
+end

--- a/spec/lib/mahonia/identifier_dispatcher_spec.rb
+++ b/spec/lib/mahonia/identifier_dispatcher_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe Mahonia::IdentifierDispatcher do
+  subject(:dispatcher) { described_class.new(registrar: fake_registrar.new) }
+  let(:identifier)     { 'moomin/123/abc' }
+  let(:object)         { FactoryBot.build(:etd) }
+
+  let(:fake_registrar) do
+    Class.new do
+      def initialize(*); end
+
+      def register!(*)
+        Struct.new('IdServiceRecord', :identifier).new('moomin/123/abc')
+      end
+    end
+  end
+
+  shared_examples 'performs identifier assignment' do |method|
+    it 'returns the same object' do
+      expect(dispatcher.public_send(method, object: object)).to eql object
+    end
+
+    it 'assigns to the identifier attribute by default' do
+      dispatcher.public_send(method, object: object)
+      expect(object.identifier).to contain_exactly(identifier)
+    end
+
+    it 'assigns to specified attribute when requested' do
+      dispatcher.public_send(method, object: object, attribute: :keyword)
+      expect(object.keyword).to contain_exactly(identifier)
+    end
+  end
+
+  it 'has a registrar' do
+    expect(dispatcher.registrar).to be_a fake_registrar
+  end
+
+  describe '.for' do
+    it 'chooses the right registrar type' do
+      expect(described_class.for(:datacite).registrar)
+        .to be_a Mahonia::DataciteRegistrar
+    end
+
+    it 'raises an error when a fake registrar type is passes' do
+      expect { described_class.for(:NOT_A_REAL_TYPE) }
+        .to raise_error ArgumentError
+    end
+  end
+
+  describe '#assign_for' do
+    include_examples 'performs identifier assignment', :assign_for
+  end
+
+  describe '#assign_for!' do
+    include_examples 'performs identifier assignment', :assign_for!
+
+    it 'saves the object' do
+      expect { dispatcher.assign_for!(object: object) }
+        .to change { object.new_record? }
+        .from(true)
+        .to(false)
+    end
+  end
+end

--- a/spec/lib/mahonia/identifier_registrar_spec.rb
+++ b/spec/lib/mahonia/identifier_registrar_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Mahonia::IdentifierRegistrar do
+  describe '.for' do
+    it 'raises an error when a fake registrar type is passes' do
+      expect { described_class.for(:NOT_A_REAL_TYPE) }.to raise_error ArgumentError
+    end
+
+    it 'chooses the right registrar type' do
+      expect(described_class.for(:datacite)).to be_a Mahonia::DataciteRegistrar
+    end
+  end
+end


### PR DESCRIPTION
Adds a `DataciteActor` and a `DataciteRegisterJob` for asynchronous registration of datacite ids.

Below these two, we have also added patterns ported from `epigaea` and its Handle registration. We have an `IdentifierDispatcher` whose job is to assign registered ids to a given object. This uses an (abstract) `IdentifierRegistrar` which handles communication to the upstream identifier registration service.

An extremely simple dummy implementation of a `DataciteRegistrar` is also included to support integration testing up to the `Actor` layer. This will need to be extended later to support the Datacite API.

This is WIP toward #30. As of this PR, none of the code here is ever loaded or used by the production app.