### PR TITLE
Change Keyword Predicate

### DIFF
--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -8,10 +8,10 @@ class Etd < ActiveFedora::Base
 
   self.human_readable_type = 'Etd'
 
-  apply_schema Schemas::CoreMetadata
-  apply_schema Schemas::EtdMetadata
-
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata
+
+  apply_schema Schemas::CoreMetadata, Schemas::GeneratedResourceSchemaStrategy.new
+  apply_schema Schemas::EtdMetadata,  Schemas::GeneratedResourceSchemaStrategy.new
 end

--- a/app/models/schemas/core_metadata.rb
+++ b/app/models/schemas/core_metadata.rb
@@ -1,6 +1,7 @@
 module Schemas
   class CoreMetadata < ActiveTriples::Schema
     property :date_label,  predicate: RDF::Vocab::DWC.verbatimEventDate
+    property :keyword,     predicate: RDF::Vocab::SCHEMA.keywords
     property :rights_note, predicate: RDF::Vocab::DC11.rights
   end
 end

--- a/app/models/schemas/generated_resource_schema_strategy.rb
+++ b/app/models/schemas/generated_resource_schema_strategy.rb
@@ -1,0 +1,17 @@
+module Schemas
+  ##
+  # An extension strategy to apply schema changes to the underlying AT model if it
+  # has already been generated.
+  class GeneratedResourceSchemaStrategy < ActiveFedora::SchemaIndexingStrategy
+    ##
+    # @see SchemaIndexingStrategy#apply
+    def apply(object, property)
+      result = super
+
+      klass = object.instance_variable_get(:@generated_resource_class)
+      return result unless klass
+      klass.property property.name, property.to_h
+      result
+    end
+  end
+end

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Etd do
   subject(:etd) { FactoryGirl.build(:etd) }
 
-  it_behaves_like 'a model with basic metadata'
+  it_behaves_like 'a model with basic metadata', except: :keyword
   it_behaves_like 'a model with ohsu core metadata'
   it_behaves_like 'a model with ohsu ETD metadata'
 

--- a/spec/support/shared_examples/core_metadata.rb
+++ b/spec/support/shared_examples/core_metadata.rb
@@ -2,5 +2,6 @@ RSpec.shared_examples 'a model with ohsu core metadata' do
   subject(:model) { described_class.new }
 
   it { is_expected.to have_editable_property(:date_label,  RDF::Vocab::DWC.verbatimEventDate) }
+  it { is_expected.to have_editable_property(:keyword,     RDF::Vocab::SCHEMA.keywords) }
   it { is_expected.to have_editable_property(:rights_note, RDF::Vocab::DC11.rights) }
 end

--- a/spec/support/shared_examples/hyrax_basic_metadata.rb
+++ b/spec/support/shared_examples/hyrax_basic_metadata.rb
@@ -1,7 +1,9 @@
-RSpec.shared_examples 'a model with core metadata' do
+RSpec.shared_examples 'a model with core metadata' do |**opts|
   subject(:model) { described_class.new }
+  let(:except)    { Array(opts[:except]) }
 
   it do
+    skip if except.include?(:date_modified)
     is_expected
       .to have_editable_property(:date_modified)
       .with_predicate(RDF::Vocab::DC.modified)
@@ -9,6 +11,7 @@ RSpec.shared_examples 'a model with core metadata' do
   end
 
   it do
+    skip if except.include?(:date_uploaded)
     is_expected
       .to have_editable_property(:date_uploaded)
       .with_predicate(RDF::Vocab::DC.dateSubmitted)
@@ -16,6 +19,7 @@ RSpec.shared_examples 'a model with core metadata' do
   end
 
   it do
+    skip if except.include?(:depositor)
     is_expected
       .to have_editable_property(:depositor)
       .with_predicate(RDF::Vocab::MARCRelators.dpt)
@@ -24,25 +28,32 @@ RSpec.shared_examples 'a model with core metadata' do
 
   describe '#first_title' do
     it 'is nil when empty' do
+      skip if except.include?(:first_title) || except.include?(:title)
       expect(model.first_title).to be_nil
     end
 
     it 'is a single title' do
+      skip if except.include?(:first_title) || except.include?(:title)
       expect { model.title = ['Comet in Moominland', 'Moomin Midwinter'] }
         .to change { model.first_title }
         .to an_instance_of(String)
     end
   end
 
-  it { is_expected.to have_editable_property(:title, RDF::Vocab::DC.title) }
+  it do
+    skip if except.include?(:title)
+    is_expected.to have_editable_property(:title, RDF::Vocab::DC.title)
+  end
 end
 
-RSpec.shared_examples 'a model with basic metadata' do
+RSpec.shared_examples 'a model with basic metadata' do |**opts|
   subject(:model) { described_class.new }
+  let(:except)    { Array(opts[:except]) }
 
-  it_behaves_like 'a model with core metadata'
+  it_behaves_like 'a model with core metadata', opts
 
   it do
+    skip if except.include?(:label)
     is_expected
       .to have_editable_property(:label)
       .with_predicate('info:fedora/fedora-system:def/model#downloadFilename')
@@ -50,6 +61,7 @@ RSpec.shared_examples 'a model with basic metadata' do
   end
 
   it do
+    skip if except.include?(:relative_path)
     is_expected
       .to have_editable_property(:relative_path)
       .with_predicate('http://scholarsphere.psu.edu/ns#relativePath')
@@ -57,27 +69,87 @@ RSpec.shared_examples 'a model with basic metadata' do
   end
 
   it do
+    skip if except.include?(:import_url)
     is_expected
       .to have_editable_property(:import_url)
       .with_predicate('http://scholarsphere.psu.edu/ns#importUrl')
       .as_single_valued
   end
 
-  it { is_expected.to have_editable_property(:bibliographic_citation, RDF::Vocab::DC.bibliographicCitation) }
-  it { is_expected.to have_editable_property(:contributor, RDF::Vocab::DC11.contributor) }
-  it { is_expected.to have_editable_property(:creator, RDF::Vocab::DC11.creator) }
-  it { is_expected.to have_editable_property(:date_created, RDF::Vocab::DC.created) }
-  it { is_expected.to have_editable_property(:description, RDF::Vocab::DC11.description) }
-  it { is_expected.to have_editable_property(:identifier, RDF::Vocab::DC.identifier) }
-  it { is_expected.to have_editable_property(:keyword, RDF::Vocab::DC11.relation) }
-  it { is_expected.to have_editable_property(:language, RDF::Vocab::DC11.language) }
-  it { is_expected.to have_editable_property(:license, RDF::Vocab::DC.rights) }
-  it { is_expected.to have_editable_property(:publisher, RDF::Vocab::DC11.publisher) }
-  it { is_expected.to have_editable_property(:related_url, RDF::RDFS.seeAlso) }
-  it { is_expected.to have_editable_property(:resource_type, RDF::Vocab::DC.type) }
-  it { is_expected.to have_editable_property(:rights_statement, RDF::Vocab::EDM.rights) }
-  it { is_expected.to have_editable_property(:source, RDF::Vocab::DC.source) }
-  it { is_expected.to have_editable_property(:subject, RDF::Vocab::DC11.subject) }
+  it do
+    skip if except.include?(:bibliographic_citation)
+    is_expected.to have_editable_property(:bibliographic_citation, RDF::Vocab::DC.bibliographicCitation)
+  end
+
+  it do
+    skip if except.include?(:contributor)
+    is_expected.to have_editable_property(:contributor, RDF::Vocab::DC11.contributor)
+  end
+
+  it do
+    skip if except.include?(:creator)
+    is_expected.to have_editable_property(:creator, RDF::Vocab::DC11.creator)
+  end
+
+  it do
+    skip if except.include?(:date_created)
+    is_expected.to have_editable_property(:date_created, RDF::Vocab::DC.created)
+  end
+
+  it do
+    skip if except.include?(:description)
+    is_expected.to have_editable_property(:description, RDF::Vocab::DC11.description)
+  end
+
+  it do
+    skip if except.include?(:identifier)
+    is_expected.to have_editable_property(:identifier, RDF::Vocab::DC.identifier)
+  end
+
+  it do
+    skip if except.include?(:keyword)
+    is_expected.to have_editable_property(:keyword, RDF::Vocab::DC11.relation)
+  end
+
+  it do
+    skip if except.include?(:language)
+    is_expected.to have_editable_property(:language, RDF::Vocab::DC11.language)
+  end
+
+  it do
+    skip if except.include?(:license)
+    is_expected.to have_editable_property(:license, RDF::Vocab::DC.rights)
+  end
+
+  it do
+    skip if except.include?(:publisher)
+    is_expected.to have_editable_property(:publisher, RDF::Vocab::DC11.publisher)
+  end
+
+  it do
+    skip if except.include?(:related_url)
+    is_expected.to have_editable_property(:related_url, RDF::RDFS.seeAlso)
+  end
+
+  it do
+    skip if except.include?(:resource_type)
+    is_expected.to have_editable_property(:resource_type, RDF::Vocab::DC.type)
+  end
+
+  it do
+    skip if except.include?(:rights_statement)
+    is_expected.to have_editable_property(:rights_statement, RDF::Vocab::EDM.rights)
+  end
+
+  it do
+    skip if
+    is_expected.to have_editable_property(:source, RDF::Vocab::DC.source)
+  end
+
+  it do
+    skip if except.include?(:subject)
+    is_expected.to have_editable_property(:subject, RDF::Vocab::DC11.subject)
+  end
 
   describe '#based_near' do
     it 'builds as a location'


### PR DESCRIPTION
Add an option to shared examples for basic and core metadata to skip tests for given fields.

Skip the basic metadata tests for `keyword` and overwrite the keyword definition. A temporary work-around for samvera/active_fedora#847 is added to open up the overwrite. That should be removed when that ticket is closed.

Closes #54.