### PR TITLE
Date uploaded

### DIFF
--- a/app/indexers/etd_indexer.rb
+++ b/app/indexers/etd_indexer.rb
@@ -14,9 +14,10 @@ class EtdIndexer < Hyrax::WorkIndexer
   #
   # This adds the specialized Etd fields
   class IndexingService < Hyrax::DeepIndexingService
+    self.stored_fields += []
     self.stored_and_facetable_fields +=
-      [:date_label, :degree, :department, :institution, :license, :orcid_id,
-       :school, :rights_statement]
+      [:date_label, :date_created, :degree, :department, :institution, :license,
+       :orcid_id, :school, :rights_statement]
 
     stored_fields.delete(:license)
     stored_fields.delete(:rights_statement)

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -29,6 +29,11 @@ class SolrDocument
     self[Solrizer.solr_name('date_label')]
   end
 
+  # first is called at https://github.com/samvera/hyrax/blob/b161167a07650f1b873e2ada838d1784a8db02e1/app/views/shared/_citations.html.erb#L22
+  def date_created
+    fetch(Solrizer.solr_name('date_created', type: :date), [])
+  end
+
   def degree
     self[Solrizer.solr_name('degree')]
   end

--- a/app/presenters/hyrax/etd_presenter.rb
+++ b/app/presenters/hyrax/etd_presenter.rb
@@ -1,6 +1,6 @@
 module Hyrax
   class EtdPresenter < Hyrax::WorkShowPresenter
-    delegate :date_label, :degree, :department, :institution, :orcid_id, :school,
-             to: :solr_document
+    delegate :date_created, :date_label, :degree, :department, :institution,
+             :orcid_id, :school, to: :solr_document
   end
 end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -10,7 +10,7 @@
 <%= presenter.attribute_to_html(:language, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:identifier, render_as: :linked, search_field: 'identifier_tesim') %>
 <%= presenter.attribute_to_html(:keyword, render_as: :faceted) %>
-<%= presenter.attribute_to_html(:date_created, render_as: :linked, search_field: 'date_created_tesim') %>
+<%= presenter.attribute_to_html(:date_created, render_as: :linked, search_field: 'date_created_desim') %>
 <%= presenter.attribute_to_html(:date_label) %>
 <%= presenter.attribute_to_html(:based_near_label) %>
 <%= presenter.attribute_to_html(:related_url, render_as: :external_link) %>

--- a/spec/factories/etds.rb
+++ b/spec/factories/etds.rb
@@ -25,6 +25,9 @@ FactoryBot.define do
 
     factory :moomins_thesis do
       creator          ['Moomin', 'Hemulen']
+      date_created     [Date.parse('2016-12-25')]
+      date_modified    DateTime.current
+      date_uploaded    DateTime.current
       date_label       ['Winter in Moomin Valley']
       degree           ['M.Phil.']
       department       ['Coin Collecting']

--- a/spec/indexers/etd_indexer_spec.rb
+++ b/spec/indexers/etd_indexer_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe EtdIndexer do
   describe '#rdf_service' do
     it 'has facetable fields' do
       expect(indexer.rdf_service.stored_and_facetable_fields)
-        .to include(:creator, :contributor, :keyword, :subject,
-                    :language, :publisher, :rights_statement)
+        .to include(:creator, :contributor, :date_label, :date_created,
+                    :keyword, :subject, :language, :publisher,
+                    :rights_statement)
     end
   end
 end

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -28,13 +28,22 @@ RSpec.describe Etd do
   end
 
   describe '#date_uploaded' do
-    subject(:etd) { FactoryBot.actor_create(:etd) }
-    let(:xmas)    { DateTime.parse('2017-12-25 11:30').iso8601 }
+    let(:time) { DateTime.current }
 
-    before { allow(Hyrax::TimeService).to receive(:time_in_utc) { xmas } }
+    it 'is a DateTime' do
+      expect { etd.date_uploaded = time }
+        .to change { etd.date_uploaded }
+        .to be_a DateTime
+    end
 
-    it 'is set by actor stack' do
-      expect(etd.date_uploaded).to eq xmas
+    context 'when created through a work actor' do
+      subject(:etd) { FactoryBot.actor_create(:etd) }
+
+      before { allow(Hyrax::TimeService).to receive(:time_in_utc) { time } }
+
+      it 'is set by actor stack' do
+        expect(etd.date_uploaded).to eq time
+      end
     end
   end
 

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -27,6 +27,17 @@ RSpec.describe Etd do
     end
   end
 
+  describe '#date_uploaded' do
+    subject(:etd) { FactoryBot.actor_create(:etd) }
+    let(:xmas)    { DateTime.parse('2017-12-25 11:30').iso8601 }
+
+    before { allow(Hyrax::TimeService).to receive(:time_in_utc) { xmas } }
+
+    it 'is set by actor stack' do
+      expect(etd.date_uploaded).to eq xmas
+    end
+  end
+
   describe '#title' do
     it 'validates presence' do
       etd = FactoryGirl.build(:etd, title: [])

--- a/spec/presenters/hyrax/etd_presenter_spec.rb
+++ b/spec/presenters/hyrax/etd_presenter_spec.rb
@@ -9,9 +9,10 @@ RSpec.describe Hyrax::EtdPresenter, type: :presenter do
 
   describe '#export_as_ttl' do
     let(:expected_fields) do
-      [:creator, :date_label, :degree, :department, :identifier, :institution,
-       :license, :orcid_id, :title, :resource_type, :rights_note,
-       :rights_statement, :school, :source, :subject]
+      [:creator, :date_created, :date_label, :date_modified, :date_uploaded,
+       :degree, :department, :identifier, :institution, :license, :orcid_id,
+       :title, :resource_type, :rights_note, :rights_statement, :school,
+       :source, :subject]
     end
 
     let(:properties) { etd.class.properties }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,6 +17,9 @@ FactoryGirl = FactoryBot unless defined?(FactoryGirl)
 
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
+# Register custom FactoryBot strategies
+FactoryBot.register_strategy(:actor_create, ActorCreate)
+
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!

--- a/spec/support/build_strategies/actor_create.rb
+++ b/spec/support/build_strategies/actor_create.rb
@@ -1,0 +1,26 @@
+class ActorCreate
+  def initialize
+    @assciation_strategy = FactoryBot.strategy_by_name(:create).new
+  end
+
+  delegate :association, to: :@association_strategy
+
+  def result(evaluation)
+    evaluation.object.tap do |instance|
+      evaluation.notify(:after_build, instance)
+
+      # @todo: is there a better way to get the evaluator at this stage?
+      #   how should we handle a missing user?
+      ability = Ability.new(evaluation.instance_variable_get(:@evaluator).user)
+      env     = Hyrax::Actors::Environment.new(instance, ability, {})
+      # @todo: generalize to use correct actors and middleware
+      actor   = Hyrax::Actors::EtdActor.new(Hyrax::Actors::Terminator.new)
+
+      evaluation.notify(:before_create,       instance)
+      evaluation.notify(:before_actor_create, instance)
+      actor.create(env)
+      evaluation.notify(:after_create,       instance)
+      evaluation.notify(:after_actor_create, instance)
+    end
+  end
+end

--- a/spec/views/catalog/_index_list_default.html.erb_spec.rb
+++ b/spec/views/catalog/_index_list_default.html.erb_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe 'catalog/_index_list_default', type: :view do
   end
 
   it 'displays desired fields' do
-    is_expected.to list_index_fields('Creator', 'Date Label', 'Degree Name',
-                                     'Keyword', 'Document Type', 'Subject')
+    is_expected.to list_index_fields('Creator', 'Date Label', 'Date Modified',
+                                     'Date Uploaded', 'Degree Name', 'Keyword',
+                                     'Document Type', 'Subject')
   end
 end

--- a/spec/views/hyrax/base/_attribute_rows.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_attribute_rows.html.erb_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe 'hyrax/base/_attribute_rows.html.erb', type: :view do
   let(:work)          { FactoryGirl.build(:moomins_thesis) }
 
   it { is_expected.to have_show_field(:creator).with_values(*work.creator).and_label('Creator') }
+  # underspecify date values (they aren't necessarily sensible for all Date/DateTime values)
+  it { is_expected.to have_show_field(:date_created).with_label('Date created') }
   it { is_expected.to have_show_field(:date_label).with_values(*work.date_label).and_label('Date label') }
   it { is_expected.to have_show_field(:degree).with_values(*work.degree).and_label('Degree Name') }
   it { is_expected.to have_show_field(:department).with_values(*work.department).and_label('Department') }


### PR DESCRIPTION
Tests that `date_uploaded` is set automatically on item submission.

Also tests `date_created` and `date_modified`.

Adds a [`FactoryBot` build strategy](https://github.com/thoughtbot/factory_bot/blob/master/GETTING_STARTED.md#custom-strategies) for pushing an item through the `EtdActor`.