### PR TITLE
Support `date` field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -114,6 +114,9 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("rights_statement", :stored_searchable), helper_method: :rights_statement_links
     config.add_show_field solr_name("license", :stored_searchable)
 
+    # Core show fields
+    config.add_show_field solr_name('date',        :stored_searchable)
+
     # ETD show fields
     config.add_show_field solr_name('date_label',  :stored_searchable)
     config.add_show_field solr_name('degree',      :stored_searchable)

--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -3,8 +3,8 @@ module Hyrax
     SINGLE_VALUE = [:degree, :school, :department].freeze
 
     self.model_class = ::Etd
-    self.terms += [:degree, :date_label, :department, :institution, :orcid_id,
-                   :resource_type, :rights_note, :school]
+    self.terms += [:degree, :date, :date_label, :department, :institution,
+                   :orcid_id, :resource_type, :rights_note, :school]
 
     ##
     # @return [Boolean]

--- a/app/indexers/etd_indexer.rb
+++ b/app/indexers/etd_indexer.rb
@@ -16,8 +16,8 @@ class EtdIndexer < Hyrax::WorkIndexer
   class IndexingService < Hyrax::DeepIndexingService
     self.stored_fields += []
     self.stored_and_facetable_fields +=
-      [:date_label, :date_created, :degree, :department, :institution, :license,
-       :orcid_id, :school, :rights_statement]
+      [:date, :date_label, :date_created, :degree, :department, :institution,
+       :license, :orcid_id, :school, :rights_statement]
 
     stored_fields.delete(:license)
     stored_fields.delete(:rights_statement)

--- a/app/models/schemas/core_metadata.rb
+++ b/app/models/schemas/core_metadata.rb
@@ -1,5 +1,6 @@
 module Schemas
   class CoreMetadata < ActiveTriples::Schema
+    property :date,        predicate: RDF::Vocab::DC11.date
     property :date_label,  predicate: RDF::Vocab::DWC.verbatimEventDate
     property :keyword,     predicate: RDF::Vocab::SCHEMA.keywords
     property :rights_note, predicate: RDF::Vocab::DC11.rights

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -25,6 +25,10 @@ class SolrDocument
 
   use_extension(Hydra::ContentNegotiation)
 
+  def date
+    self[Solrizer.solr_name('date')]
+  end
+
   def date_label
     self[Solrizer.solr_name('date_label')]
   end

--- a/app/presenters/hyrax/etd_presenter.rb
+++ b/app/presenters/hyrax/etd_presenter.rb
@@ -1,6 +1,6 @@
 module Hyrax
   class EtdPresenter < Hyrax::WorkShowPresenter
-    delegate :date_created, :date_label, :degree, :department, :institution,
+    delegate :date, :date_label, :degree, :department, :institution, :orcid_id,
              :orcid_id, :school, to: :solr_document
   end
 end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -11,6 +11,7 @@
 <%= presenter.attribute_to_html(:identifier, render_as: :linked, search_field: 'identifier_tesim') %>
 <%= presenter.attribute_to_html(:keyword, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:date_created, render_as: :linked, search_field: 'date_created_desim') %>
+<%= presenter.attribute_to_html(:date) %>
 <%= presenter.attribute_to_html(:date_label) %>
 <%= presenter.attribute_to_html(:based_near_label) %>
 <%= presenter.attribute_to_html(:related_url, render_as: :external_link) %>

--- a/spec/factories/etds.rb
+++ b/spec/factories/etds.rb
@@ -25,10 +25,11 @@ FactoryBot.define do
 
     factory :moomins_thesis do
       creator          ['Moomin', 'Hemulen']
+      date             ['199?']
       date_created     [Date.parse('2016-12-25')]
+      date_label       ['Winter in Moomin Valley']
       date_modified    DateTime.current
       date_uploaded    DateTime.current
-      date_label       ['Winter in Moomin Valley']
       degree           ['M.Phil.']
       department       ['Coin Collecting']
       identifier       ['Moomin_123']

--- a/spec/indexers/etd_indexer_spec.rb
+++ b/spec/indexers/etd_indexer_spec.rb
@@ -7,9 +7,8 @@ RSpec.describe EtdIndexer do
   describe '#rdf_service' do
     it 'has facetable fields' do
       expect(indexer.rdf_service.stored_and_facetable_fields)
-        .to include(:creator, :contributor, :date_label, :date_created,
-                    :keyword, :subject, :language, :publisher,
-                    :rights_statement)
+        .to include(:date, :date_created, :date_label, :creator, :contributor,
+                    :keyword, :subject, :language, :publisher, :rights_statement)
     end
   end
 end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -4,6 +4,21 @@ RSpec.describe SolrDocument do
   subject(:solr_document) { described_class.new(etd.to_solr) }
   let(:etd)               { FactoryGirl.build(:etd) }
 
+  describe '#date' do
+    it 'is nil when empty' do
+      expect(solr_document.date).to be_nil
+    end
+
+    context 'with dates' do
+      let(:date) { ['199?'] }
+      let(:etd)  { FactoryGirl.build(:etd, date: date) }
+
+      it 'matches the model dates' do
+        expect(solr_document.date).to contain_exactly(*date)
+      end
+    end
+  end
+
   describe '#date_label' do
     it 'is nil when empty' do
       expect(solr_document.date_label).to be_nil

--- a/spec/presenters/hyrax/etd_presenter_spec.rb
+++ b/spec/presenters/hyrax/etd_presenter_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe Hyrax::EtdPresenter, type: :presenter do
 
   describe '#export_as_ttl' do
     let(:expected_fields) do
-      [:creator, :date_created, :date_label, :date_modified, :date_uploaded,
-       :degree, :department, :identifier, :institution, :license, :orcid_id,
-       :title, :resource_type, :rights_note, :rights_statement, :school,
-       :source, :subject]
+      [:creator, :date, :date_created, :date_label, :date_modified,
+       :date_uploaded, :degree, :department, :identifier, :institution,
+       :license, :orcid_id, :title, :resource_type, :rights_note,
+       :rights_statement, :school, :source, :subject]
     end
 
     let(:properties) { etd.class.properties }

--- a/spec/support/shared_examples/core_metadata.rb
+++ b/spec/support/shared_examples/core_metadata.rb
@@ -1,6 +1,7 @@
 RSpec.shared_examples 'a model with ohsu core metadata' do
   subject(:model) { described_class.new }
 
+  it { is_expected.to have_editable_property(:date,        RDF::Vocab::DC11.date) }
   it { is_expected.to have_editable_property(:date_label,  RDF::Vocab::DWC.verbatimEventDate) }
   it { is_expected.to have_editable_property(:keyword,     RDF::Vocab::SCHEMA.keywords) }
   it { is_expected.to have_editable_property(:rights_note, RDF::Vocab::DC11.rights) }

--- a/spec/views/catalog/_index_list_default.html.erb_spec.rb
+++ b/spec/views/catalog/_index_list_default.html.erb_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'catalog/_index_list_default', type: :view do
 
   # title appears in a different partial, not in the metadata listing
   it 'does not display undesired fields' do
-    is_expected.not_to list_index_fields('Title', 'Language', 'Source',
+    is_expected.not_to list_index_fields('Title', 'Date', 'Language', 'Source',
                                          'Identifier', 'Rights Note', 'Rights',
                                          'License')
   end

--- a/spec/views/hyrax/base/_attribute_rows.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_attribute_rows.html.erb_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'hyrax/base/_attribute_rows.html.erb', type: :view do
   it { is_expected.to have_show_field(:creator).with_values(*work.creator).and_label('Creator') }
   # underspecify date values (they aren't necessarily sensible for all Date/DateTime values)
   it { is_expected.to have_show_field(:date_created).with_label('Date created') }
+  it { is_expected.to have_show_field(:date).with_values(*work.date).and_label('Date') }
   it { is_expected.to have_show_field(:date_label).with_values(*work.date_label).and_label('Date label') }
   it { is_expected.to have_show_field(:degree).with_values(*work.degree).and_label('Degree Name') }
   it { is_expected.to have_show_field(:department).with_values(*work.department).and_label('Department') }

--- a/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
@@ -63,6 +63,13 @@ RSpec.describe 'hyrax/base/_form_metadata.html.erb', type: :view do
         .with_label 'Creator'
     end
 
+    it 'has dates' do
+      expect(page)
+        .to have_multivalued_field(:date)
+        .on_model(work.class)
+        .with_label 'Date'
+    end
+
     it 'has date labels' do
       expect(page)
         .to have_multivalued_field(:date_label)


### PR DESCRIPTION
Adds the date field. EDTF support is not yet added. The remaining work is to cast form values to `RDF::Literal` values with the appropriate datatype URI, and ensure those values round trip to Fedora and appear in `.ttl` serializations.

Attached to #52.