### PR TITLE
Integrate DOI assignment

### DIFF
--- a/app/jobs/datacite_register_job.rb
+++ b/app/jobs/datacite_register_job.rb
@@ -1,7 +1,11 @@
 class DataciteRegisterJob < ApplicationJob
   ##
   # @!attribute [rw] registrar_opts
-  attr_accessor :registrar_opts
+  attr_writer :registrar_opts
+
+  def registrar_opts
+    @registrar_opts ||= {}
+  end
 
   queue_as :id_service
 

--- a/app/jobs/datacite_register_job.rb
+++ b/app/jobs/datacite_register_job.rb
@@ -1,11 +1,15 @@
 class DataciteRegisterJob < ApplicationJob
+  ##
+  # @!attribute [rw] registrar_opts
+  attr_accessor :registrar_opts
+
   queue_as :id_service
 
   ##
   # @param model [ActiveFedora::Base]
   def perform(model)
     Mahonia::IdentifierDispatcher
-      .for(:datacite)
+      .for(:datacite, **registrar_opts)
       .assign_for!(object: model)
   end
 end

--- a/app/lib/datacite/configuration.rb
+++ b/app/lib/datacite/configuration.rb
@@ -1,0 +1,32 @@
+module Datacite
+  class Configuration
+    include Singleton
+
+    ##
+    # @!attribute [rw] domains
+    #   @return [String]
+    # @!attribute [rw] login
+    #   @return [String]
+    # @!attribute [rw] password
+    #   @return [String]
+    # @!attribute [rw] prefix
+    #   @return [String]
+    # @!attribute [rw] test_prefix
+    #   @return [String]
+    attr_accessor :domains, :login, :password, :prefix
+
+    def initialize
+      load_from_hash(Rails.application.config_for(:datacite)) if defined? Rails
+    end
+
+    ##
+    # @param hash [Hash]
+    # @return [Datacite::Configuration] self
+    def load_from_hash(hash)
+      self.domains  = hash.fetch('domains')
+      self.login    = hash.fetch('login')
+      self.password = hash.fetch('password')
+      self.prefix   = hash.fetch('prefix')
+    end
+  end
+end

--- a/app/lib/datacite/connection.rb
+++ b/app/lib/datacite/connection.rb
@@ -1,0 +1,27 @@
+module Datacite
+  class Connection
+    ##
+    # @!attribute [rw] configuration
+    #   @return [Datacite::Configuration]
+    # @!attribute [r] connection
+    attr_accessor :configuration
+    attr_reader   :connection
+
+    ##
+    # @param configuration [Datacite::Configuration]
+    def initialize(configuration: Datacite::Configuration.instance)
+      @configuration = configuration
+      @connection    = Faraday.new(url: 'https://mds.test.datacite.org/')
+      @connection.basic_auth configuration.login, configuration.password
+    end
+
+    ##
+    # @param metadata [#identifier]
+    # @return [#identifier] the registered metadata record
+    def create(metadata:)
+      # headers = {:"Content-Type" => "application/xml" }
+      # connection.post('/metadata', 'moomin', headers)
+      metadata
+    end
+  end
+end

--- a/app/lib/mahonia/datacite_doi_builder.rb
+++ b/app/lib/mahonia/datacite_doi_builder.rb
@@ -1,0 +1,16 @@
+module Mahonia
+  ##
+  # An identifier builder that builds DataCite DOIs in the way recommended by
+  #  the DataCite Metadata Store (MDS) API documentation.
+  #
+  # @see https://support.datacite.org/docs/mds-2
+  class DataciteDoiBuilder < IdentifierBuilder
+    ##
+    # @note hints are ignored
+    #
+    # @see IdentifierBuilder#build
+    def build(*)
+      '10.5555/1234'
+    end
+  end
+end

--- a/app/lib/mahonia/datacite_doi_builder.rb
+++ b/app/lib/mahonia/datacite_doi_builder.rb
@@ -6,11 +6,17 @@ module Mahonia
   # @see https://support.datacite.org/docs/mds-2
   class DataciteDoiBuilder < IdentifierBuilder
     ##
+    # @see IdentifierBuilder#initialize
+    def initialize(prefix: Datacite::Configuration.instance.prefix)
+      super
+    end
+
+    ##
     # @note hints are ignored
     #
     # @see IdentifierBuilder#build
     def build(*)
-      '10.5555/1234'
+      prefix + '/1234'
     end
   end
 end

--- a/app/lib/mahonia/datacite_registrar.rb
+++ b/app/lib/mahonia/datacite_registrar.rb
@@ -3,15 +3,23 @@ module Mahonia
     IdentifierRecord = Struct.new(:identifier)
 
     ##
+    # @!attribute [rw] connection
+    #   @return [Datacite::Connection]
+    attr_accessor :connection
+
+    ##
     # @param builder [Mahonia::IdentifierBuilder]
-    def initialize(builder: Mahonia::DataciteDoiBuilder.new)
-      super
+    def initialize(builder:    Mahonia::DataciteDoiBuilder.new,
+                   connection: Datacite::Connection.new)
+      @connection = connection
+      super(builder: builder)
     end
 
     ##
     # @see IdentifierRegistrar#register!
     def register!(*)
-      IdentifierRecord.new(builder.build)
+      record = IdentifierRecord.new(builder.build)
+      connection.create(metadata: record)
     end
   end
 end

--- a/app/lib/mahonia/datacite_registrar.rb
+++ b/app/lib/mahonia/datacite_registrar.rb
@@ -2,8 +2,16 @@ module Mahonia
   class DataciteRegistrar < IdentifierRegistrar
     IdentifierRecord = Struct.new(:identifier)
 
+    ##
+    # @param builder [Mahonia::IdentifierBuilder]
+    def initialize(builder: Mahonia::DataciteDoiBuilder.new)
+      super
+    end
+
+    ##
+    # @see IdentifierRegistrar#register!
     def register!(*)
-      IdentifierRecord.new('moomin')
+      IdentifierRecord.new(builder.build)
     end
   end
 end

--- a/app/lib/mahonia/identifier_builder.rb
+++ b/app/lib/mahonia/identifier_builder.rb
@@ -1,0 +1,38 @@
+module Mahonia
+  ##
+  # Builds an identifier string.
+  #
+  # @example
+  #   builder = IdentifierBuilder.new(prefix: 'moomin')
+  #   builder.build(hint: '1') # => "moomin/1"
+  class IdentifierBuilder
+    ##
+    # @!attribute prefix [rw]
+    #   @return [String] the prefix to use when building identifiers
+    attr_accessor :prefix
+
+    ##
+    # @param prefix [String] the prefix to use when building identifiers
+    def initialize(prefix: 'pfx')
+      @prefix = prefix
+    end
+
+    ##
+    # @note this default builder requires a `hint` which it appends to the
+    #   prefix to generate the identifier string.
+    #
+    # @param hint [#to_s] a string-able object which may be used by the builder
+    #   to generate an identifier. Hints may be required by some builders, while
+    #   others may ignore them to generate an identifier by other means.
+    #
+    # @return [String]
+    # @raise [ArgumentError] if an identifer can't be built from the provided
+    #   hint.
+    def build(hint: nil)
+      raise(ArgumentError, "No hint provided to #{self.class}#build") if
+        hint.nil?
+
+      "#{prefix}/#{hint}"
+    end
+  end
+end

--- a/app/lib/mahonia/identifier_dispatcher.rb
+++ b/app/lib/mahonia/identifier_dispatcher.rb
@@ -13,13 +13,15 @@ module Mahonia
 
     class << self
       ##
-      # @param type [Symbol]
+      # @param type           [Symbol]
+      # @param registrar_opts [Hash]
+      # @option registrar_opts [Mahonia::IdentifierBuilder] :builder
       #
       # @return [IdentifierDispatcher] a dispatcher with an registrar for the
       #   given type
       # @see IdentifierRegistrar.for
-      def for(type)
-        new(registrar: Mahonia::IdentifierRegistrar.for(type))
+      def for(type, **registrar_opts)
+        new(registrar: Mahonia::IdentifierRegistrar.for(type, **registrar_opts))
       end
     end
 

--- a/app/lib/mahonia/identifier_registrar.rb
+++ b/app/lib/mahonia/identifier_registrar.rb
@@ -1,17 +1,31 @@
 module Mahonia
   class IdentifierRegistrar
     class << self
+      ##
       # @param type [Symbol]
+      # @param opts [Hash]
+      # @option opts [Mahonia::IdentifierBuilder] :builder
       #
       # @return [IdentifierRegistrar] a  registrar for the given type
-      def for(type)
+      def for(type, **opts)
         case type
         when :datacite
-          'Mahonia::DataciteRegistrar'.constantize.new
+          'Mahonia::DataciteRegistrar'.constantize.new(**opts)
         else
           raise ArgumentError, "IdentifierRegistrar not found to handle #{type}"
         end
       end
+    end
+
+    ##
+    # @!attribute builder [rw]
+    #   @return [Mahonia::IdentifierBuilder]
+    attr_accessor :builder
+
+    ##
+    # @param builder [Mahonia::IdentifierBuilder]
+    def initialize(builder:)
+      @builder = builder
     end
 
     ##

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,5 +13,9 @@ module Mahonia
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    config.to_prepare do
+      Hyrax::CurationConcern.actor_factory.use Hyrax::Actors::DataciteActor
+    end
   end
 end

--- a/config/datacite.yml
+++ b/config/datacite.yml
@@ -1,0 +1,18 @@
+---
+development:
+  domains:   '*'
+  login:    'DATACITE.DCE'
+  password: 'mahoniaD0I'
+  prefix:   '10.24354'
+
+test:
+  domains:   '*'
+  login:    'DATACITE.DCE'
+  password: 'mahoniaD0I'
+  prefix:   '10.5072'
+
+production:
+  domains:   '*'
+  login:    'DATACITE.DCE'
+  password: 'mahoniaD0I'
+  prefix:   '10.24354'

--- a/spec/fakes/fake_datacite_connection.rb
+++ b/spec/fakes/fake_datacite_connection.rb
@@ -1,0 +1,9 @@
+class FakeDataciteConnection
+  def initialize(*)
+    @dois = {}
+  end
+
+  def create(metadata:)
+    @dois[metadata.identifier] = metadata
+  end
+end

--- a/spec/fakes/fake_identifier_builder.rb
+++ b/spec/fakes/fake_identifier_builder.rb
@@ -1,0 +1,23 @@
+class FakeIdentifierBuilder
+  attr_accessor :ids
+
+  def initialize(*ids)
+    @ids = ids
+    @ids = ['OneFreeId'] if @ids.empty?
+  end
+
+  def build(*)
+    @enum_ids ||= ids.to_enum
+    @enum_ids.next
+  end
+end
+
+# rubocop:disable RSpec/FilePath
+RSpec.describe FakeIdentifierBuilder do
+  it_behaves_like 'an IdentifierBuilder'
+
+  describe '#build' do
+    it 'returns the given ids in order'
+  end
+end
+# rubocop:enable RSpec/FilePath

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -3,12 +3,15 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.feature 'Create a Etd', js: false do
+RSpec.feature 'Create a Etd', js: false, perform_enqueued: true do
   context 'as a logged in user' do
     let(:title) { 'Comet in Moominland' }
     let(:user)  { FactoryGirl.create(:user) }
 
-    before { login_as user }
+    before do
+      ActiveJob::Base.queue_adapter.filter = [DataciteRegisterJob]
+      login_as user
+    end
 
     scenario 'creating' do
       visit '/dashboard'
@@ -26,7 +29,8 @@ RSpec.feature 'Create a Etd', js: false do
 
       find('#with_files_submit').click
 
-      expect(page).to have_content title
+      expect(page).to have_content title # sets title
+      expect(page).to have_css('.identifier', text: '10.5072') # assigns DOI
     end
 
     scenario 'editing' do

--- a/spec/jobs/datacite_register_job_spec.rb
+++ b/spec/jobs/datacite_register_job_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'fakes/fake_identifier_builder'
 
 RSpec.describe DataciteRegisterJob, type: :job do
   let(:object) { create(:etd) }
@@ -14,11 +15,20 @@ RSpec.describe DataciteRegisterJob, type: :job do
     end
   end
 
-  describe '.perform_now' do
+  describe '.perform' do
+    subject(:job) do
+      described_class.new.tap do |job|
+        job.registrar_opts = { builder: builder }
+      end
+    end
+
+    let(:builder) { FakeIdentifierBuilder.new(id) }
+    let(:id)      { 'moomin' }
+
     it 'adds an id to the object' do
-      expect { described_class.perform_now(object) }
+      expect { job.perform(object) }
         .to change { object.identifier.to_a }
-        .to contain_exactly 'moomin'
+        .to contain_exactly id
     end
   end
 end

--- a/spec/jobs/datacite_register_job_spec.rb
+++ b/spec/jobs/datacite_register_job_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'fakes/fake_datacite_connection'
 require 'fakes/fake_identifier_builder'
 
 RSpec.describe DataciteRegisterJob, type: :job do
@@ -18,12 +19,13 @@ RSpec.describe DataciteRegisterJob, type: :job do
   describe '.perform' do
     subject(:job) do
       described_class.new.tap do |job|
-        job.registrar_opts = { builder: builder }
+        job.registrar_opts = { builder: builder, connection: connection }
       end
     end
 
-    let(:builder) { FakeIdentifierBuilder.new(id) }
-    let(:id)      { 'moomin' }
+    let(:builder)    { FakeIdentifierBuilder.new(id) }
+    let(:connection) { FakeDataciteConnection.new }
+    let(:id)         { 'moomin' }
 
     it 'adds an id to the object' do
       expect { job.perform(object) }

--- a/spec/lib/datacite/configuration_spec.rb
+++ b/spec/lib/datacite/configuration_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Datacite::Configuration do
+  subject(:config) { described_class.instance }
+
+  it 'loads attributes from Rails config file' do
+    expect(config).to have_attributes domains:  an_instance_of(String),
+                                      login:    an_instance_of(String),
+                                      password: an_instance_of(String),
+                                      prefix:   an_instance_of(String)
+  end
+
+  describe '#load_from_hash' do
+    let(:hash) do
+      { 'domains'  => 'hash_domains',
+        'login'    => 'hash_login',
+        'password' => 'hash_password',
+        'prefix'   => 'hash_prefix' }
+    end
+
+    it 'loads settings from the hash' do
+      config.load_from_hash(hash)
+
+      expect(config).to have_attributes hash
+    end
+  end
+
+  context 'with manually set attributes' do
+    before do
+      config.domains  = 'domains'
+      config.login    = 'login'
+      config.password = 'password'
+      config.prefix   = 'prefix'
+    end
+
+    it do
+      is_expected.to have_attributes domains:  'domains',
+                                     login:    'login',
+                                     password: 'password',
+                                     prefix:   'prefix'
+    end
+  end
+end

--- a/spec/lib/datacite/configuration_spec.rb
+++ b/spec/lib/datacite/configuration_spec.rb
@@ -3,6 +3,12 @@ require 'rails_helper'
 RSpec.describe Datacite::Configuration do
   subject(:config) { described_class.instance }
 
+  after(:all) do
+    described_class
+      .instance
+      .load_from_hash Rails.application.config_for(:datacite)
+  end
+
   it 'loads attributes from Rails config file' do
     expect(config).to have_attributes domains:  an_instance_of(String),
                                       login:    an_instance_of(String),

--- a/spec/lib/datacite/connection_spec.rb
+++ b/spec/lib/datacite/connection_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Datacite::Connection do
+  subject(:connection) { described_class.new }
+
+  it do
+    is_expected
+      .to have_attributes(configuration: Datacite::Configuration.instance,
+                          connection:    an_instance_of(Faraday::Connection))
+  end
+
+  # rubocop:disable RSpec/VerifiedDoubles
+  # We are happy to use an unverified double, since we aren't picky the metadata
+  # behavior as long as it responds to identifier
+  describe '#create' do
+    let(:identifier) { '10.55555/moomin' }
+    let(:metadata)   { double(identifier: identifier) }
+
+    it 'returns a record with the same identifier' do
+      expect(connection.create(metadata: metadata).identifier).to eq identifier
+    end
+  end
+  # rubocop:enable RSpec/VerifiedDoubles
+end

--- a/spec/lib/mahonia/datacite_doi_builder_spec.rb
+++ b/spec/lib/mahonia/datacite_doi_builder_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Mahonia::DataciteDoiBuilder do
+  subject(:builder) { described_class.new }
+
+  it_behaves_like 'an IdentifierBuilder'
+
+  describe '#build' do
+    it 'generates unique ids with cirneco'
+  end
+end

--- a/spec/lib/mahonia/datacite_registrar_spec.rb
+++ b/spec/lib/mahonia/datacite_registrar_spec.rb
@@ -1,6 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe Mahonia::DataciteRegistrar do
+  subject(:registrar) { described_class.new }
+  let(:model)         { :REPLACE_ME_WITH_A_MODEL }
+
+  it_behaves_like 'an IdentifierRegistrar'
+
+  describe '#builder' do
+    it 'has a default bulider' do
+      expect(registrar.builder).to be_a Mahonia::DataciteDoiBuilder
+    end
+  end
+
   describe '#register!' do
     it 'registers a datacite id'
   end

--- a/spec/lib/mahonia/identifier_builder_spec.rb
+++ b/spec/lib/mahonia/identifier_builder_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe Mahonia::IdentifierBuilder do
+  subject(:builder) { described_class.new }
+
+  it_behaves_like 'an IdentifierBuilder'
+
+  describe '#prefix' do
+    it 'has a default prefix' do
+      expect(builder.prefix).not_to be_empty
+    end
+
+    it 'accepts a prefix' do
+      prefix = 'my_pfx'
+      builder = described_class.new(prefix: prefix)
+      expect(builder.prefix).to eq prefix
+    end
+  end
+
+  describe '#build' do
+    it 'uses the prefix' do
+      expect(builder.build(hint: 'blah')).to start_with "#{builder.prefix}/"
+    end
+
+    context 'with a custom prefix' do
+      subject(:builder) { described_class.new(prefix: prefix) }
+      let(:prefix)      { 'fake_prefix' }
+
+      it 'uses the prefix' do
+        expect(builder.build(hint: 'blah')).to start_with "#{prefix}/"
+      end
+    end
+
+    it 'raises an error with no hint' do
+      expect { builder.build }.to raise_error ArgumentError
+    end
+
+    it 'uses the hint exactly, cast to uppercase' do
+      expect(builder.build(hint: 'moomin')).to eq 'pfx/moomin'
+    end
+  end
+end

--- a/spec/lib/mahonia/identifier_registrar_spec.rb
+++ b/spec/lib/mahonia/identifier_registrar_spec.rb
@@ -1,13 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Mahonia::IdentifierRegistrar do
-  describe '.for' do
-    it 'raises an error when a fake registrar type is passes' do
-      expect { described_class.for(:NOT_A_REAL_TYPE) }.to raise_error ArgumentError
-    end
-
-    it 'chooses the right registrar type' do
-      expect(described_class.for(:datacite)).to be_a Mahonia::DataciteRegistrar
-    end
-  end
+  it_behaves_like 'an IdentifierRegistrar'
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,6 +22,9 @@ Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 # Register custom FactoryBot strategies
 FactoryBot.register_strategy(:actor_create, ActorCreate)
 
+# Remove a deprecated FactoryBot feature that causes problems for doubles
+FactoryBot.allow_class_lookup = false
+
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!

--- a/spec/support/shared_examples/identifier_builder.rb
+++ b/spec/support/shared_examples/identifier_builder.rb
@@ -1,0 +1,10 @@
+RSpec.shared_examples 'an IdentifierBuilder' do
+  subject(:builder) { described_class.new }
+
+  describe '#build' do
+    it 'returns an identifier string' do
+      expect(builder.build(hint: 'moomin'))
+        .to respond_to :to_str
+    end
+  end
+end

--- a/spec/support/shared_examples/identifier_registrar.rb
+++ b/spec/support/shared_examples/identifier_registrar.rb
@@ -1,0 +1,28 @@
+RSpec.shared_examples 'an IdentifierRegistrar' do
+  subject(:registrar) { described_class.new(builder: builder) }
+  let(:abstract)      { described_class == Mahonia::IdentifierRegistrar }
+  let(:builder)       { instance_double(Mahonia::IdentifierBuilder, build: 'moomin') }
+  let(:object)        { :object }
+
+  it { is_expected.to have_attributes(builder: builder) }
+
+  describe '.for' do
+    it 'raises an error when a fake registrar type is passes' do
+      expect { described_class.for(:NOT_A_REAL_TYPE, builder: builder) }
+        .to raise_error ArgumentError
+    end
+
+    it 'chooses the right registrar type' do
+      expect(described_class.for(:datacite, builder: builder))
+        .to be_a Mahonia::DataciteRegistrar
+    end
+  end
+
+  describe '#register!' do
+    it 'creates an identifier record' do
+      skip if abstract
+      expect(registrar.register!(object: object).identifier)
+        .to respond_to :to_str
+    end
+  end
+end


### PR DESCRIPTION
This implements DOI assignment through to the Datacite API layer.

Configuration for Datacite is set up, and the actor is wired into the stack. Feature and unit tests are introduced to ensure that the DOI is assigned as expected.