### PR TITLE
Reformat `department.yml` to correct terms list

### DIFF
--- a/config/authorities/department.yml
+++ b/config/authorities/department.yml
@@ -1,163 +1,163 @@
 terms:
 - id:   Department of Adult Health and Illness
-- term: Department of Adult Health and Illness
+  term: Department of Adult Health and Illness
 - id:   Department of Anatomy
-- term: Department of Anatomy
+  term: Department of Anatomy
 - id:   Department of Applied Physics
-- term: Department of Applied Physics
+  term: Department of Applied Physics
 - id:   Department of Applied Physics and Electronic Science
-- term: Department of Applied Physics and Electronic Science
+  term: Department of Applied Physics and Electronic Science
 - id:   Department of Atmospheric Physics
-- term: Department of Atmospheric Physics
+  term: Department of Atmospheric Physics
 - id:   Department of Bacteriology
-- term: Department of Bacteriology
+  term: Department of Bacteriology
 - id:   Department of Bacteriology and Hygiene
-- term: Department of Bacteriology and Hygiene
+  term: Department of Bacteriology and Hygiene
 - id:   Department of Behavioral Neuroscience
-- term: Department of Behavioral Neuroscience
+  term: Department of Behavioral Neuroscience
 - id:   Department of Biochemistry
-- term: Department of Biochemistry
+  term: Department of Biochemistry
 - id:   Department of Biochemistry and Molecular Biology
-- term: Department of Biochemistry and Molecular Biology
+  term: Department of Biochemistry and Molecular Biology
 - id:   Department of Biomaterials and Biomechanics
-- term: Department of Biomaterials and Biomechanics
+  term: Department of Biomaterials and Biomechanics
 - id:   Department of Biomedical Computer Science
-- term: Department of Biomedical Computer Science
+  term: Department of Biomedical Computer Science
 - id:   Department of Biomedical Engineering
-- term: Department of Biomedical Engineering
+  term: Department of Biomedical Engineering
 - id:   Department of Biomedical Informatics
-- term: Department of Biomedical Informatics
+  term: Department of Biomedical Informatics
 - id:   Department of Biomedical Informatics and Clinical Epidemiology
-- term: Department of Biomedical Informatics and Clinical Epidemiology
+  term: Department of Biomedical Informatics and Clinical Epidemiology
 - id:   Department of Cancer Biology
-- term: Department of Cancer Biology
+  term: Department of Cancer Biology
 - id:   Department of Cell and Developmental Biology
-- term: Department of Cell and Developmental Biology
+  term: Department of Cell and Developmental Biology
 - id:   Department of Cell Biology and Anatomy
-- term: Department of Cell Biology and Anatomy
+  term: Department of Cell Biology and Anatomy
 - id:   Department of Cell, Developmental, and Cancer Biology
-- term: Department of Cell, Developmental, and Cancer Biology
+  term: Department of Cell, Developmental, and Cancer Biology
 - id:   Department of Chemistry
-- term: Department of Chemistry
+  term: Department of Chemistry
 - id:   Department of Chemistry and Biochemical Sciences
-- term: Department of Chemistry and Biochemical Sciences
+  term: Department of Chemistry and Biochemical Sciences
 - id:   Department of Clinical Pathology
-- term: Department of Clinical Pathology
+  term: Department of Clinical Pathology
 - id:   Department of Computer Science and Electrical Engineering
-- term: Department of Computer Science and Electrical Engineering
+  term: Department of Computer Science and Electrical Engineering
 - id:   Department of Computer Science and Engineering
-- term: Department of Computer Science and Engineering
+  term: Department of Computer Science and Engineering
 - id:   Department of Dental Materials
-- term: Department of Dental Materials
+  term: Department of Dental Materials
 - id:   Department of Dietetics and Nutrition
-- term: Department of Dietetics and Nutrition
+  term: Department of Dietetics and Nutrition
 - id:   Department of Electrical and Computer Engineering
-- term: Department of Electrical and Computer Engineering
+  term: Department of Electrical and Computer Engineering
 - id:   Department of Electrical and Computer Science
-- term: Department of Electrical and Computer Science
+  term: Department of Electrical and Computer Science
 - id:   Department of Electrical Engineering
-- term: Department of Electrical Engineering
+  term: Department of Electrical Engineering
 - id:   Department of Endodontics
-- term: Department of Endodontics
+  term: Department of Endodontics
 - id:   Department of Endodontology
-- term: Department of Endodontology
+  term: Department of Endodontology
 - id:   Department of Environmental and Biomolecular Systems
-- term: Department of Environmental and Biomolecular Systems
+  term: Department of Environmental and Biomolecular Systems
 - id:   Department of Environmental Science
-- term: Department of Environmental Science
+  term: Department of Environmental Science
 - id:   Department of Environmental Science and Engineering
-- term: Department of Environmental Science and Engineering
+  term: Department of Environmental Science and Engineering
 - id:   Department of Environmental Technology
-- term: Department of Environmental Technology
+  term: Department of Environmental Technology
 - id:   Department of Epidemiology
-- term: Department of Epidemiology
+  term: Department of Epidemiology
 - id:   Department of Experimental Pathology
-- term: Department of Experimental Pathology
+  term: Department of Experimental Pathology
 - id:   Department of Family Nursing
-- term: Department of Family Nursing
+  term: Department of Family Nursing
 - id:   Department of Integrated Biomedical Sciences
-- term: Department of Integrated Biomedical Sciences
+  term: Department of Integrated Biomedical Sciences
 - id:   Department of Materials Science
-- term: Department of Materials Science
+  term: Department of Materials Science
 - id:   Department of Materials Science and Engineering
-- term: Department of Materials Science and Engineering
+  term: Department of Materials Science and Engineering
 - id:   Department of Medical and Molecular Genetics
-- term: Department of Medical and Molecular Genetics
+  term: Department of Medical and Molecular Genetics
 - id:   Department of Medical Genetics
-- term: Department of Medical Genetics
+  term: Department of Medical Genetics
 - id:   Department of Medical Informatics
-- term: Department of Medical Informatics
+  term: Department of Medical Informatics
 - id:   Department of Medical Informatics and Clinical Epidemiology
-- term: Department of Medical Informatics and Clinical Epidemiology
+  term: Department of Medical Informatics and Clinical Epidemiology
 - id:   Department of Medical Informatics and Outcome Resarch
-- term: Department of Medical Informatics and Outcome Resarch
+  term: Department of Medical Informatics and Outcome Resarch
 - id:   Department of Medical Informatics and Outcomes Research
-- term: Department of Medical Informatics and Outcomes Research
+  term: Department of Medical Informatics and Outcomes Research
 - id:   Department of Medical Microbiology and Immunology
-- term: Department of Medical Microbiology and Immunology
+  term: Department of Medical Microbiology and Immunology
 - id:   Department of Medical Physiology
-- term: Department of Medical Physiology
+  term: Department of Medical Physiology
 - id:   Department of Medical Psychology
-- term: Department of Medical Psychology
+  term: Department of Medical Psychology
 - id:   Department of Medicine
-- term: Department of Medicine
+  term: Department of Medicine
 - id:   Department of Mental Health Nursing
-- term: Department of Mental Health Nursing
+  term: Department of Mental Health Nursing
 - id:   Department of Micobiology and Immunology
-- term: Department of Micobiology and Immunology
+  term: Department of Micobiology and Immunology
 - id:   Department of Microbiology
-- term: Department of Microbiology
+  term: Department of Microbiology
 - id:   Department of Microbiology and Immunology
-- term: Department of Microbiology and Immunology
+  term: Department of Microbiology and Immunology
 - id:   Department of Microbiology and Molecular Immunology
-- term: Department of Microbiology and Molecular Immunology
+  term: Department of Microbiology and Molecular Immunology
 - id:   Department of Molecular and Medical Genetics
-- term: Department of Molecular and Medical Genetics
+  term: Department of Molecular and Medical Genetics
 - id:   Department of Molecular Microbiology and Immunology
-- term: Department of Molecular Microbiology and Immunology
+  term: Department of Molecular Microbiology and Immunology
 - id:   Department of Molecular Microbiology and Immunology
-- term: Department of Molecular Microbiology and Immunology
+  term: Department of Molecular Microbiology and Immunology
 - id:   Department of Neurobiology
-- term: Department of Neurobiology
+  term: Department of Neurobiology
 - id:   Department of Neuroscience
-- term: Department of Neuroscience
+  term: Department of Neuroscience
 - id:   Department of Nursing
-- term: Department of Nursing
+  term: Department of Nursing
 - id:   Department of Nursing Education
-- term: Department of Nursing Education
+  term: Department of Nursing Education
 - id:   Department of Operative Dentistry
-- term: Department of Operative Dentistry
+  term: Department of Operative Dentistry
 - id:   Department of Oral Molecular Biology
-- term: Department of Oral Molecular Biology
+  term: Department of Oral Molecular Biology
 - id:   Department of Oral Pathology
-- term: Department of Oral Pathology
+  term: Department of Oral Pathology
 - id:   Department of Orthodontics
-- term: Department of Orthodontics
+  term: Department of Orthodontics
 - id:   Department of Pathology
-- term: Department of Pathology
+  term: Department of Pathology
 - id:   Department of Pediatric Dentistry
-- term: Department of Pediatric Dentistry
+  term: Department of Pediatric Dentistry
 - id:   Department of Pedodontics
-- term: Department of Pedodontics
+  term: Department of Pedodontics
 - id:   Department of Periodontology
-- term: Department of Periodontology
+  term: Department of Periodontology
 - id:   Department of Pharmacology
-- term: Department of Pharmacology
+  term: Department of Pharmacology
 - id:   Department of Physiology
-- term: Department of Physiology
+  term: Department of Physiology
 - id:   Department of Physiology and Pharmacology
-- term: Department of Physiology and Pharmacology
+  term: Department of Physiology and Pharmacology
 - id:   Department of Psychiatric/Mental Health Nursing
-- term: Department of Psychiatric/Mental Health Nursing
+  term: Department of Psychiatric/Mental Health Nursing
 - id:   Department of Public Health
-- term: Department of Public Health
+  term: Department of Public Health
 - id:   Department of Public Health and Preventive Medicine
-- term: Department of Public Health and Preventive Medicine
+  term: Department of Public Health and Preventive Medicine
 - id:   Department of Science and Engineering
-- term: Department of Science and Engineering
+  term: Department of Science and Engineering
 - id:   Department Public Health and Preventive Medicine
-- term: Department Public Health and Preventive Medicine
+  term: Department Public Health and Preventive Medicine
 - id:   Deptartment of Environmental and Biomolecular Systems
-- term: Deptartment of Environmental and Biomolecular Systems
+  term: Deptartment of Environmental and Biomolecular Systems
 - id:   Deptartment of Environmental Science and Engineering
-- term: Deptartment of Environmental Science and Engineering
+  term: Deptartment of Environmental Science and Engineering


### PR DESCRIPTION
The terms list contained duplicated items, each with *either* an `id` or a `term`. This fixes each term to have both.

I believe it's appropriate *not* to test this change, since we want the configuration to be correct. An alternative would be to provide a local authority linter that could catch errors like this (e.g. `WARNING: some of your authority terms do not have a required 'id'`).

Closes #149.