### PR TITLE
Fixes to cap deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -15,7 +15,7 @@ set :assets_prefix, "#{shared_path}/public/assets"
 
 SSHKit.config.command_map[:rake] = 'bundle exec rake'
 
-set :branch, ENV['REVISION'] || ENV['BRANCH_NAME'] || 'master'
+set :branch, ENV['REVISION'] || ENV['BRANCH_NAME'] || ENV['BRANCH'] || 'master'
 
 append :linked_dirs, "log"
 append :linked_dirs, "public/assets"

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,10 +4,10 @@
   - [default, 1]
 
 test:
-  :concurrency: ENV['SIDKEKIQ_CONCURRENCY']
+  :concurrency: <%= ENV['SIDEKIQ_CONCURRENCY'] || 5 %>
 
 development:
-  :concurrency: ENV['SIDKEKIQ_CONCURRENCY']
+  :concurrency: <%= ENV['SIDEKIQ_CONCURRENCY'] || 5 %>
 
 production:
-  :concurrency: ENV['SIDKEKIQ_CONCURRENCY']
+  :concurrency: <%= ENV['SIDEKIQ_CONCURRENCY'] || 5 %>


### PR DESCRIPTION
Fix reference to SIDEKIQ_CONCURRENCY
Use ERB to interpret environment variables
Deploy regardless of whether someone has set the BRANCH or the BRANCH_NAME variable