### PR TITLE
Pass metadata to Datacite from registration job

### DIFF
--- a/app/lib/mahonia/datacite_registrar.rb
+++ b/app/lib/mahonia/datacite_registrar.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 module Mahonia
   class DataciteRegistrar < IdentifierRegistrar
-    IdentifierRecord = Struct.new(:identifier)
+    IdentifierRecord =
+      Struct.new(:identifier, :creator, :publisher, :publication_year, :title)
 
     ##
     # @!attribute [rw] connection
@@ -18,10 +19,19 @@ module Mahonia
     end
 
     ##
+    # @return [Mahonia::DataciteRegistrar::IdentifierRecord]
+    def record_for(object:)
+      IdentifierRecord.new(builder.build(hint: object.id),
+                           object.try(:creator),
+                           object.try(:publisher),
+                           object.try(:date_uploaded).try(:year),
+                           object.try(:title))
+    end
+
+    ##
     # @see IdentifierRegistrar#register!
     def register!(object:)
-      record = IdentifierRecord.new(builder.build(hint: object.id))
-      connection.create(metadata: record)
+      connection.create(metadata: record_for(object: object))
     end
 
     private

--- a/spec/fakes/fake_datacite_connection.rb
+++ b/spec/fakes/fake_datacite_connection.rb
@@ -7,4 +7,16 @@ class FakeDataciteConnection
   def create(metadata:)
     @dois[metadata.identifier] = metadata
   end
+
+  def get(metadata:)
+    map_record(@dois[metadata.identifier])
+  end
+
+  private
+
+    ResponseRecord = Struct.new(:identifier, :titles)
+
+    def map_record(record)
+      ResponseRecord.new(record.identifier, record.try(:title))
+    end
 end

--- a/spec/jobs/datacite_register_job_spec.rb
+++ b/spec/jobs/datacite_register_job_spec.rb
@@ -33,5 +33,15 @@ RSpec.describe DataciteRegisterJob, type: :job do
         .to change { object.identifier.to_a }
         .to contain_exactly id
     end
+
+    # rubocop:disable RSpec/VerifiedDoubles
+    it 'registers the id with metadata' do
+      job.perform(object)
+
+      expect(connection.get(metadata: double(identifier: id)))
+        .to have_attributes(identifier: id,
+                            titles:     object.title)
+    end
+    # rubocop:enable RSpec/VerifiedDoubles
   end
 end

--- a/spec/lib/mahonia/identifier_dispatcher_spec.rb
+++ b/spec/lib/mahonia/identifier_dispatcher_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Mahonia::IdentifierDispatcher do
       def initialize(*); end
 
       def register!(*)
-        Struct.new('IdServiceRecord', :identifier).new('moomin/123/abc')
+        Struct.new(:identifier).new('moomin/123/abc')
       end
     end
   end


### PR DESCRIPTION
Ensures that metadata passed to DataCite from the registration job is passed along to the server.

Connected to #30.