### PR TITLE
Add feature tests for ETD visibility

### DIFF
--- a/spec/factories/etds.rb
+++ b/spec/factories/etds.rb
@@ -24,6 +24,10 @@ FactoryBot.define do
       visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     end
 
+    factory :authenticated_etd do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+    end
+
     factory :moomins_thesis do
       creator          ['Moomin', 'Hemulen']
       date             ['199?']

--- a/spec/features/access_etd_spec.rb
+++ b/spec/features/access_etd_spec.rb
@@ -3,35 +3,113 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 RSpec.feature 'Access an Etd', js: false do
-  let(:etd)         { FactoryGirl.create(:public_etd, pdf: pdf) }
-  let(:pdf)         { FactoryGirl.create(:pdf_upload) }
-  let(:private_etd) { FactoryGirl.create(:etd, pdf: pdf) }
+  let(:etd) { FactoryGirl.create(:public_etd, pdf: pdf) }
+  let(:pdf) { FactoryGirl.create(:pdf_upload) }
 
-  scenario 'searching submitted ETDs' do
-    visit '/'
+  # Only enqueue the ingest job, not charactarization.
+  before { ActiveJob::Base.queue_adapter.filter = [IngestJob] }
 
-    fill_in 'Search Hyrax', with: etd.first_title
-    click_button 'Go'
+  shared_examples 'open access to public etds' do
+    scenario 'searching submitted public etd' do
+      visit '/'
 
-    within(:css, "li#document_#{etd.id}") do
-      expect(page).to have_content etd.first_title
+      fill_in 'Search Hyrax', with: etd.first_title
+      click_button 'Go'
+
+      within(:css, "li#document_#{etd.id}") do
+        expect(page).to have_content etd.first_title
+      end
+    end
+
+    context 'with ingested file', :perform_enqueued do
+      scenario 'downloading is allowed for public etd' do
+        visit      "concern/etds/#{etd.id}"
+        click_link "Download \"#{etd.representative.first_title}\""
+
+        expect(page.response_headers['Content-Disposition']).to include 'attachment'
+      end
     end
   end
 
-  context 'with ingested file', :perform_enqueued do
-    # Only enqueue the ingest job, not charactarization.
-    before { ActiveJob::Base.queue_adapter.filter = [IngestJob] }
+  shared_context 'restricted access to private etds' do
+    let(:private_etd) { FactoryGirl.create(:etd, pdf: pdf) }
 
-    scenario 'downloading' do
-      visit      "concern/etds/#{etd.id}"
-      click_link "Download \"#{etd.representative.first_title}\""
+    scenario 'searching private etd is restricted' do
+      visit '/'
 
-      expect(page.response_headers['Content-Disposition']).to include 'attachment'
+      fill_in 'Search Hyrax', with: private_etd.first_title
+      click_button 'Go'
+
+      expect(page).not_to have_css("li#document_#{private_etd.id}")
     end
 
-    scenario 'downloading restricted' do
+    scenario 'browsing to private etd is restricted' do
       visit "concern/etds/#{private_etd.id}"
-      expect(page).not_to have_content 'Download'
+
+      expect(page).not_to have_content private_etd.title
+      # Hyrax doesn't seem to give a consistent error message!
+      # expect(page).to have_content 'private'
+      # expect(page).to have_content 'not authorized'
     end
+
+    context 'with ingested file', :perform_enqueued do
+      scenario 'downloading is restricted for private etds' do
+        visit "concern/etds/#{private_etd.id}"
+        expect(page).not_to have_content 'Download'
+      end
+    end
+  end
+
+  context 'as unauthenticated user' do
+    before { logout }
+
+    include_context 'open access to public etds'
+    include_context 'restricted access to private etds'
+
+    let(:institutional_etd) { FactoryGirl.create(:authenticated_etd, pdf: pdf) }
+
+    scenario 'searching institutional etd is restricted' do
+      visit '/'
+
+      fill_in 'Search Hyrax', with: institutional_etd.first_title
+      click_button 'Go'
+
+      expect(page).not_to have_css("li#document_#{institutional_etd.id}")
+    end
+
+    scenario 'browsing to institutional etd is restricted' do
+      visit "concern/etds/#{institutional_etd.id}"
+
+      expect(page).not_to have_content institutional_etd.title
+      # Hyrax doesn't seem to give a consistent error message!
+      # expect(page).to have_content 'private'
+      # expect(page).to have_content 'not authorized'
+    end
+
+    context 'with ingested file', :perform_enqueued do
+      scenario 'downloading is restricted for institutional etds' do
+        visit "concern/etds/#{institutional_etd.id}"
+        expect(page).not_to have_content 'Download'
+      end
+    end
+  end
+
+  context 'as non-admin user' do
+    let(:user) { FactoryBot.create(:user) }
+
+    before { login_as user }
+    after(:context) { logout }
+
+    include_context 'open access to public etds'
+    include_context 'restricted access to private etds'
+  end
+
+  context 'as admin user' do
+    let(:user) { FactoryBot.create(:user) }
+
+    before { login_as user }
+    after(:context) { logout }
+
+    include_context 'open access to public etds'
   end
 end


### PR DESCRIPTION
Build out feature specs for visibility of public, institutional/authorized, and private ETDs.

Hyrax's error messages for unauthorized access vary between explaining to the user that they are 'not authorized' and that the page is 'private'. For now we are satisfied with checking that the title doesn't appear on the page when unauthorized access is attempted.

This commit omits specific tests for admin access to non-public visibilities. We intend here to test the restrictions.

Closes #46 