### PR TITLE
Complete registration of DOIs with DataCite's Handle Backend

### DIFF
--- a/app/lib/mahonia/citation_formatter.rb
+++ b/app/lib/mahonia/citation_formatter.rb
@@ -56,8 +56,8 @@ module Mahonia
     end
 
     def url
-      return unless object.id
-      Rails.application.routes.url_helpers.hyrax_etd_url(object.id)
+      return unless (id = object.id)
+      Etd.application_url(id: id)
     end
   end
 end

--- a/app/lib/mahonia/datacite_registrar.rb
+++ b/app/lib/mahonia/datacite_registrar.rb
@@ -31,7 +31,12 @@ module Mahonia
     ##
     # @see IdentifierRegistrar#register!
     def register!(object:)
-      connection.create(metadata: record_for(object: object))
+      metadata = record_for(object: object)
+
+      result = connection.create(metadata: metadata)
+      connection.register(metadata: result,
+                          url:      Etd.application_url(id: object.id))
+      result
     end
 
     private

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -15,4 +15,22 @@ class Etd < ActiveFedora::Base
 
   apply_schema Schemas::CoreMetadata, Schemas::GeneratedResourceSchemaStrategy.new
   apply_schema Schemas::EtdMetadata,  Schemas::GeneratedResourceSchemaStrategy.new
+
+  ##
+  # @param id [String]
+  #
+  # @return [String] the url for an etd with the current id
+  def self.application_url(id:)
+    Rails.application.routes.url_helpers.hyrax_etd_url(id)
+  end
+
+  ##
+  # @param id [String]
+  #
+  # @return [String]
+  # @raise [ArgumentError] if the object does not have an id
+  def application_url
+    raise ArgumentError, "Tried to build a URL for new record #{self}" unless id
+    self.class.application_url(id: id)
+  end
 end

--- a/spec/fakes/fake_datacite_connection.rb
+++ b/spec/fakes/fake_datacite_connection.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
+##
+# A fake connection to DataCite.
+#
+# `#dois` and `#registered` are offered as spies.
 class FakeDataciteConnection
+  attr_reader :dois, :registered
+
   def initialize(*)
-    @dois = {}
+    @dois       = {}
+    @registered = {}
   end
 
   def create(metadata:)
@@ -10,6 +17,10 @@ class FakeDataciteConnection
 
   def get(metadata:)
     map_record(@dois[metadata.identifier])
+  end
+
+  def register(metadata:, url:)
+    @registered[metadata.identifier] = url
   end
 
   private

--- a/spec/lib/mahonia/datacite_registrar_spec.rb
+++ b/spec/lib/mahonia/datacite_registrar_spec.rb
@@ -67,5 +67,11 @@ RSpec.describe Mahonia::DataciteRegistrar do
       expect(registrar.register!(object: model))
         .to have_attributes(**mapped_hash)
     end
+
+    it 'sends a request to update the handle registration' do
+      expect { registrar.register!(object: model) }
+        .to change { registrar.connection.registered } # spy
+        .to include(doi => 'http://localhost:3000/concern/etds/moomin_id')
+    end
   end
 end

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -28,6 +28,31 @@ RSpec.describe Etd do
     end
   end
 
+  describe '.application_url' do
+    let(:id) { 'moomin_id' }
+
+    it 'returns a url' do
+      expect(described_class.application_url(id: id)).to end_with id
+    end
+  end
+
+  describe '#application_url' do
+    context 'with no id set' do
+      it 'raises an ArgumentError' do
+        expect { etd.application_url }.to raise_error ArgumentError
+      end
+    end
+
+    context 'with an id' do
+      subject(:etd) { FactoryGirl.build(:etd, id: id) }
+      let(:id)      { 'moomin_id' }
+
+      it 'returns a url' do
+        expect(etd.application_url).to end_with id
+      end
+    end
+  end
+
   describe '#date_uploaded' do
     let(:time) { DateTime.current }
 


### PR DESCRIPTION
The MDS API runs a two step registration process where Step 1 creates a metadata record in the MDS, and Step 2 creates a handle record linking to the target URL.

This implements support for the second step and wires the `DataciteRegistrar` up to complete the registration process.

`FakeDataciteConnection` is extended to support testing this, including by adding spy attributes to check its iternal state. Unfortunately, due to Handle system TTLs, there is no way to provide such immediate feedback in the real implementation.

Some inline documentation is added in the process.

Closes #30.