### PR TITLE
Force users to register queues before using a new queue name

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,3 +1,23 @@
 # frozen_string_literal: true
 class ApplicationJob < ActiveJob::Base
+  KNOWN_QUEUES = [:default, :id_service].freeze
+
+  class << self
+    ##
+    # @return [Array<Symbol>] names of all known queues
+    def known_queues
+      KNOWN_QUEUES
+    end
+
+    def queue_as(name, *)
+      return super if known_queues.include?(name)
+
+      raise ArgumentError, "#{name} is not a known queue name. Named job queues " \
+                           "must be explictly setup to run in the development " \
+                           "and production environments for jobs enqueued with " \
+                           "them to run. Add a `[#{name}, priority] pair to " \
+                           "`config/sidekiq.yml`. Then remove this warning by " \
+                           "adding #{name} to `ApplicationJob::KNOWN_QUEUES`."
+    end
+  end
 end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ApplicationJob do
+  it_behaves_like 'an ApplicationJob'
+end

--- a/spec/jobs/datacite_register_job_spec.rb
+++ b/spec/jobs/datacite_register_job_spec.rb
@@ -6,6 +6,8 @@ require 'fakes/fake_identifier_builder'
 RSpec.describe DataciteRegisterJob, type: :job do
   let(:object) { create(:etd) }
 
+  it_behaves_like 'an ApplicationJob'
+
   describe '.perform_later' do
     before { ActiveJob::Base.queue_adapter = :test }
 

--- a/spec/support/shared_examples/application_job.rb
+++ b/spec/support/shared_examples/application_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+RSpec.shared_examples 'an ApplicationJob' do
+  describe 'retrying'
+  describe 'discarding'
+
+  describe '.queue_as' do
+    context 'when the queue is not known' do
+      it 'raises an error' do
+        expect { described_class.queue_as(:NOT_A_REAL_QUEUE) }
+          .to raise_error ArgumentError, /NOT_A_REAL_QUEUE/
+      end
+    end
+  end
+
+  describe '.known_queues' do
+    it 'contains :default' do
+      expect(described_class.known_queues).to include :default
+    end
+  end
+end


### PR DESCRIPTION
This prevents class level configuration of new queues without thinking about it. Code can help developers!