### PR TITLE
Remove unused `needs_attr_accessible?` call from User model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,9 +9,6 @@ class User < ApplicationRecord
   include Hyrax::User
   include Hyrax::UserUsageStats
 
-  if Blacklight::Utils.needs_attr_accessible?
-    attr_accessible :email, :password, :password_confirmation
-  end
   # Connects this user object to Blacklights Bookmarks.
   include Blacklight::User
   # Include default devise modules. Others available are:


### PR DESCRIPTION
It's not clear to me why Hyrax generates this call, but it's a Rails 4 migration artifact and we definitely don't need it in this code base. It should always be `nil`, and runs the risk of eventually being `NoMethodError` or worse.