### PR TITLE
Sanitize formatting for citations and mark as HTML safe

### DIFF
--- a/app/lib/mahonia/citation_formatter.rb
+++ b/app/lib/mahonia/citation_formatter.rb
@@ -26,18 +26,29 @@ module Mahonia
     end
 
     ##
-    # @return [String] a citation for the object
+    # @note this method returns an `html_safe` string
+    #   (`ActiveSupport::SafeBuffer`). It is sanitized to allow only <i>, <b>,
+    #   and <br> tags.
+    #
+    # @return [ActiveSupport::SafeBuffer] an html safe citation for the object
+    #
+    # rubocop:disable Rails/OutputSafety
     def citation
-      CiteProc::Processor
-        .new(style: 'ohsu-apa', format: 'html')
-        .import(item)
-        .render(:bibliography, id: :item)
-        .first
+      cite = CiteProc::Processor
+             .new(style: 'ohsu-apa', format: 'html')
+             .import(item)
+             .render(:bibliography, id: :item)
+             .first
+
+      Rails::Html::WhiteListSanitizer.new.sanitize(cite, tags: %w[i b br]).html_safe
     rescue CiteProc::Error, TypeError, ArgumentError
-      "#{object.creator.join(', ')}. #{object.title.first} " \
-      "(#{(object.date || []).first}). <i>Scholar Archive</i>. " \
-      "#{object.id}.#{' ' + doi if doi}\n#{url}"
+      cite = "#{object.creator.join(', ')}. #{object.title.first} " \
+             "(#{(object.date || []).first}). <i>Scholar Archive</i>. " \
+             "#{object.id}.#{' ' + doi if doi}\n#{url}"
+
+      Rails::Html::WhiteListSanitizer.new.sanitize(cite, tags: %w[i b br]).html_safe
     end
+    # rubocop:enable Rails/OutputSafety
 
     def item
       CiteProc::Item.new(id:               :item,

--- a/spec/lib/mahonia/citation_formatter_spec.rb
+++ b/spec/lib/mahonia/citation_formatter_spec.rb
@@ -7,6 +7,22 @@ RSpec.describe Mahonia::CitationFormatter do
   let(:etd)           { FactoryBot.build(:shannon_mit, id: 'shannon') }
 
   describe '#citation' do
+    context 'with injected html' do
+      let(:etd) do
+        FactoryBot.build(:shannon_mit,
+                         title:   ['<script>title</script>'],
+                         creator: ['<h1>Shannon</h1>'])
+      end
+
+      it 'is resiliant to code injection for title' do
+        expect(formatter.citation).not_to include '<script>'
+      end
+
+      it 'is resiliant to code injection for other fields' do
+        expect(formatter.citation).not_to include '<h1>'
+      end
+    end
+
     it 'has the authors' do
       expect(formatter.citation).to include 'Shannon, C. E.'
     end

--- a/spec/views/hyrax/base/_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_metadata.html.erb_spec.rb
@@ -38,8 +38,14 @@ RSpec.describe 'hyrax/base/_metadata.html.erb', type: :view do
       .and_label('License')
   end
 
-  it 'shows the citation' do
-    expect(page).to have_css('.citation', text: work.title.first)
+  describe 'citations' do
+    it 'shows the citation' do
+      expect(page).to have_css('.citation', text: work.title.first)
+    end
+
+    it 'does not include html tag for italic' do
+      expect(page).not_to have_content '<i>'
+    end
   end
 
   describe 'embargos' do


### PR DESCRIPTION
Citation formatting needs to be sanitized to avoid HTML injection from citation styles. We allow extremely simple formatting such as might be introduced by the citation processor itself, then mark as HTML safe for rendering.

Closes #182 