### PR TITLE
Avoid retrying jobs on deserialization errors for Ldp::Gone

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -2,6 +2,13 @@
 class ApplicationJob < ActiveJob::Base
   KNOWN_QUEUES = [:default, :id_service].freeze
 
+  rescue_from ActiveJob::DeserializationError do |exception|
+    raise exception unless exception.cause.is_a? Ldp::Gone
+
+    logger.warn "#{self.class} with id #{job_id} failed with #{exception.cause}." \
+                "The object passed to the job no longer exists.\n\t#{exception}\n\t"
+  end
+
   class << self
     ##
     # @return [Array<Symbol>] names of all known queues

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,12 +1,66 @@
 # frozen_string_literal: true
+
+##
+# A base class for jobs defined at the application layer of a Hyrax app. This
+# class and documentation are written with SideKiq in mind as the Queue Adapter
+# backend for ActiveJob. Using other backends (e.g. Resque) should be possible
+# with some differences in behavior.
+#
+# ### Queue Registration
+#
+# Jobs can run on various named queues, which can be configured in SideKiq to
+# run on different servers, or with different priority levels. It's necessary
+# when configuring a new queue name to ensure that the queue is setup to run in
+# development and production environments (the test `QueueAdapter` won't catch
+# missing queues). To avoid accidentally un- or under-configured queues, we
+# require adding a queue name to `.known_queues` before configuring it as the
+# default queue for the class. If `.queue_as` is called with an unknown queue
+# name, an error is raised.
+#
+# Ad-hoc queue names can still be used on a per-job basis (e.g.
+# `MyJob.set(queue: :new_queue).perform_later(*args)`) or set dynamically with
+# a block (`queue_as do; ...; end`).
+#
+# ### Error Handling & Job Retries
+#
+# Errors sometimes happen in job processing. In the normal case, our strategy
+# for handling these errors is to allow them to pass through to the job queue
+# backend, where they can be automatically retried.
+#
+# SideKiq holds onto failed jobs and retries them with an increasing time delay,
+# about 25 times in 21 days. Jobs can also be retried manually from the SideKiq
+# web UI. If Honeybadger is enabled it will track the errors coming from jobs.
+# These two interfaces make up our strategy for tracking and handling job
+# failures. Some failures may require action to resolve, either through quality
+# control of repository content or deploying bug fixes.
+#
+# When an error should not be retried, job classes can handle the error
+# directly; e.g. with `rescue_from ErrorClass`. Doing so will avoiding
+# notifications and retries. Jobs inheriting from this base class handle and log
+# errors resulting from deleted repository content
+# (`ActiveJob::DeserializationError` caused by `Ldp::Gone`), for jobs that
+# require access to permanently deleted content.
+#
+# @example
+#   class MyJob < ApplicationJob
+#     def perform(model, options)
+#       do_work(model, options)
+#     end
+#   end
+#
+# @see http://guides.rubyonrails.org/v5.0/active_job_basics.html
+# @see https://github.com/mperham/sidekiq/wiki/Error-Handling
 class ApplicationJob < ActiveJob::Base
   KNOWN_QUEUES = [:default, :id_service].freeze
 
+  ##
+  # Rescue `ActiveJob::DeserializationError` log if the cause is `Ldp::Gone`,
+  # otherwise re-raise.
   rescue_from ActiveJob::DeserializationError do |exception|
     raise exception unless exception.cause.is_a? Ldp::Gone
 
     logger.warn "#{self.class} with id #{job_id} failed with #{exception.cause}." \
-                "The object passed to the job no longer exists.\n\t#{exception}\n\t"
+                "The object passed to the job no longer exists.\n\t#{exception}"
   end
 
   class << self
@@ -16,15 +70,20 @@ class ApplicationJob < ActiveJob::Base
       KNOWN_QUEUES
     end
 
-    def queue_as(name, *)
-      return super if known_queues.include?(name)
+    def queue_as(name = nil, *)
+      return super if block_given? || known_queues.include?(name)
 
-      raise ArgumentError, "#{name} is not a known queue name. Named job queues " \
-                           "must be explictly setup to run in the development " \
-                           "and production environments for jobs enqueued with " \
-                           "them to run. Add a `[#{name}, priority] pair to " \
-                           "`config/sidekiq.yml`. Then remove this warning by " \
-                           "adding #{name} to `ApplicationJob::KNOWN_QUEUES`."
+      message = "#{name} is not a known queue name. Named job queues " \
+                "must be explictly setup to run in the development " \
+                "and production environments for jobs enqueued with " \
+                "them to run. Add a `[#{name}, priority] pair to " \
+                "`config/sidekiq.yml`. Then remove this warning by " \
+                "adding #{name} to `ApplicationJob::KNOWN_QUEUES`."
+
+      raise ArgumentError, message unless ENV['RAILS_ENV'] == 'production'
+
+      logger.warn(message)
+      super
     end
   end
 end

--- a/spec/jobs/datacite_register_job_spec.rb
+++ b/spec/jobs/datacite_register_job_spec.rb
@@ -6,7 +6,9 @@ require 'fakes/fake_identifier_builder'
 RSpec.describe DataciteRegisterJob, type: :job do
   let(:object) { create(:etd) }
 
-  it_behaves_like 'an ApplicationJob'
+  it_behaves_like 'an ApplicationJob' do
+    let(:deserialize_object) { object }
+  end
 
   describe '.perform_later' do
     before { ActiveJob::Base.queue_adapter = :test }

--- a/spec/support/shared_examples/application_job.rb
+++ b/spec/support/shared_examples/application_job.rb
@@ -1,7 +1,18 @@
 # frozen_string_literal: true
-RSpec.shared_examples 'an ApplicationJob' do
+RSpec.shared_examples 'an ApplicationJob', :perform_enqueued, type: :job do
+  # handled by SideKiq
   describe 'retrying'
-  describe 'discarding'
+
+  describe 'discarding' do
+    it 'does not raise to job queue on 410 Gone' do
+      skip 'Set an object deserialize with `let(:deserialize_object)`' unless
+        defined? deserialize_object
+      skip unless deserialize_object.is_a? ActiveFedora::Core
+
+      deserialize_object.destroy
+      expect { described_class.perform_later(deserialize_object) }.not_to raise_error
+    end
+  end
 
   describe '.queue_as' do
     context 'when the queue is not known' do


### PR DESCRIPTION
When a job tries to deserialize an object, it is possible for an error to occur. One reason for these errors is that the object has been deleted and is no longer accessible.

We know that for `ActiveFedora::Core` objects, this means the object is permanently gone and that deserialization won't succeed in the future. We choose to catch `DeserializationError` when the cause is `Ldp::Gone`, and log to avoid further retries.

4878998 makes an initial pass at documenting the error handling and queue registration strategies in `ApplicaitonJob`. We call out the intent to use `SideKiq` and `Honeybadger` to manage error notifications and retries. Some details about how to avoid retries are also provided.

The `queue_as` overwrite is fixed up slightly to handle the block setting interface provided by `ActiveJob::Base`. We also switch to logging, rather than raising errors in the production environment. This is never an error a user should encounter.

Connected to #101.