### PR TITLE
Add MeSH autocomplete to subject field.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,4 +89,6 @@ group :test do
   gem 'capybara',           '~> 2.15.4'
   gem 'coveralls',          require: false
   gem 'factory_bot_rails',  '~> 4.8.0'
+  gem 'poltergeist'
+  gem 'selenium-webdriver'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,12 +175,15 @@ GEM
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
+    childprocess (0.8.0)
+      ffi (~> 1.0, >= 1.0.11)
     citeproc (1.0.6)
       namae (~> 0.8)
     citeproc-ruby (1.1.8)
       citeproc (>= 1.0.4, < 2.0)
       csl (~> 1.4)
     clipboard-rails (1.7.1)
+    cliver (0.3.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -555,6 +558,10 @@ GEM
     parser (2.4.0.0)
       ast (~> 2.2)
     pg (0.21.0)
+    poltergeist (1.17.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      websocket-driver (>= 0.2.0)
     posix-spawn (0.3.13)
     power_converter (0.1.2)
     powerpack (0.1.1)
@@ -729,6 +736,9 @@ GEM
       tilt (>= 1.1, < 3)
     select2-rails (3.5.10)
       thor (~> 0.14)
+    selenium-webdriver (3.8.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.0)
     shex (0.5.1)
       ebnf (~> 1.1)
       json-ld (~> 2.1)
@@ -876,11 +886,13 @@ DEPENDENCIES
   jquery-rails
   listen (~> 3.0.5)
   pg
+  poltergeist
   puma (~> 3.0)
   rails (~> 5.0.6)
   rsolr (>= 1.0)
   rspec-rails
   sass-rails (~> 5.0)
+  selenium-webdriver
   sidekiq
   solr_wrapper (>= 0.3)
   spring

--- a/app/views/records/edit_fields/_subject.html.erb
+++ b/app/views/records/edit_fields/_subject.html.erb
@@ -1,0 +1,8 @@
+<%= f.input key,
+            as: :multi_value,
+            input_html: {
+              class: 'form-control',
+              data: { 'autocomplete-url' => "/authorities/search/local/subjects",
+                      'autocomplete' => key }
+            },
+            required: f.object.required?(key) %>

--- a/app/views/records/edit_fields/_subject.html.erb
+++ b/app/views/records/edit_fields/_subject.html.erb
@@ -2,7 +2,7 @@
             as: :multi_value,
             input_html: {
               class: 'form-control',
-              data: { 'autocomplete-url' => "/authorities/search/local/subjects",
+              data: { 'autocomplete-url' => "/authorities/search/mesh",
                       'autocomplete' => key }
             },
             required: f.object.required?(key) %>

--- a/db/migrate/20171215182413_create_qa_subject_mesh_terms.qa.rb
+++ b/db/migrate/20171215182413_create_qa_subject_mesh_terms.qa.rb
@@ -1,0 +1,12 @@
+# This migration comes from qa (originally 20130917200611)
+class CreateQaSubjectMeshTerms < ActiveRecord::Migration[4.2]
+  def change
+    create_table :qa_subject_mesh_terms do |t|
+      t.string :term_id
+      t.string :term
+      t.text :synonyms
+    end
+    add_index :qa_subject_mesh_terms, :term_id
+    add_index :qa_subject_mesh_terms, :term
+  end
+end

--- a/db/migrate/20171215182414_create_qa_mesh_tree.qa.rb
+++ b/db/migrate/20171215182414_create_qa_mesh_tree.qa.rb
@@ -1,0 +1,11 @@
+# This migration comes from qa (originally 20130917201026)
+class CreateQaMeshTree < ActiveRecord::Migration[4.2]
+  def change
+    create_table :qa_mesh_trees do |t|
+      t.string :term_id
+      t.string :tree_number
+    end
+    add_index :qa_mesh_trees, :term_id
+    add_index :qa_mesh_trees, :tree_number
+  end
+end

--- a/db/migrate/20171215182415_add_term_lower_to_qa_subject_mesh_terms.qa.rb
+++ b/db/migrate/20171215182415_add_term_lower_to_qa_subject_mesh_terms.qa.rb
@@ -1,0 +1,8 @@
+# This migration comes from qa (originally 20130918141523)
+class AddTermLowerToQaSubjectMeshTerms < ActiveRecord::Migration[4.2]
+  def change
+    add_column :qa_subject_mesh_terms, :term_lower, :string
+    add_index :qa_subject_mesh_terms, :term_lower
+    remove_index :qa_subject_mesh_terms, :term
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171029164826) do
+ActiveRecord::Schema.define(version: 20171215182415) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -243,6 +243,22 @@ ActiveRecord::Schema.define(version: 20171029164826) do
     t.datetime "updated_at",         null: false
     t.index ["local_authority_id"], name: "index_qa_local_authority_entries_on_local_authority_id", using: :btree
     t.index ["uri"], name: "index_qa_local_authority_entries_on_uri", unique: true, using: :btree
+  end
+
+  create_table "qa_mesh_trees", force: :cascade do |t|
+    t.string "term_id"
+    t.string "tree_number"
+    t.index ["term_id"], name: "index_qa_mesh_trees_on_term_id", using: :btree
+    t.index ["tree_number"], name: "index_qa_mesh_trees_on_tree_number", using: :btree
+  end
+
+  create_table "qa_subject_mesh_terms", force: :cascade do |t|
+    t.string "term_id"
+    t.string "term"
+    t.text   "synonyms"
+    t.string "term_lower"
+    t.index ["term_id"], name: "index_qa_subject_mesh_terms_on_term_id", using: :btree
+    t.index ["term_lower"], name: "index_qa_subject_mesh_terms_on_term_lower", using: :btree
   end
 
   create_table "roles", force: :cascade do |t|

--- a/spec/features/autocomplete_mesh_spec.rb
+++ b/spec/features/autocomplete_mesh_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.feature 'Autocomplete MeSH terms', :clean, mesh: true, js: true do
+  let(:admin) { FactoryBot.create(:admin) }
+  before do
+    import_mesh_terms
+    login_as admin
+  end
+
+  scenario 'autocompleting MeSH terms in the subject field on form' do
+    visit '/concern/etds/new'
+    expect(page).to have_content('Additional fields')
+    click_on 'Additional fields'
+
+    # Check that we get the correct autocompletion from QA
+    find('#etd_subject').send_keys 'sulfameraz'
+    expect(page).to have_content('Sulfamerazine')
+
+    # Fill out the rest of the form
+    find('ul.ui-autocomplete li.ui-menu-item', text: 'Sulfamerazine').click
+    fill_in 'Title', with: 'MeSH Test'
+    fill_in 'Creator', with: 'Creator'
+    fill_in 'Keyword', with: 'Keyword'
+    select 'In Copyright', from: 'Rights'
+    find('body').click
+
+    # Add a file
+    click_link "Files" # switch tab
+    expect(page).to have_content "Add files"
+    within('span#addfiles') do
+      attach_file('files[]', File.absolute_path(file_fixture('pdf-sample.pdf')), visible: false)
+    end
+    expect(page).to have_content('Delete')
+
+    # Submit the form
+    expect(page).to have_selector('#with_files_submit')
+    find('#with_files_submit').click
+
+    # Check that the page has Sulfamerazine
+    expect(page).to have_content 'Sulfamerazine'
+    expect(page).to have_content 'MeSH Test'
+    expect(page).to have_content 'In Copyright'
+  end
+end

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -4,7 +4,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.feature 'Create an ETD', js: false do
+RSpec.feature 'Create an ETD', :clean, js: false do
   let(:title) { 'Comet in Moominland' }
   let(:admin) { FactoryBot.create(:admin) }
   let(:user) { FactoryBot.create(:user) }
@@ -19,7 +19,10 @@ RSpec.feature 'Create an ETD', js: false do
   after { logout }
 
   context 'an admin user' do
-    before { login_as admin }
+    before do
+      login_as admin
+      AdminSet.find_or_create_default_admin_set_id
+    end
 
     scenario 'can create a work', :perform_enqueued, :datacite_api do
       ActiveJob::Base.queue_adapter.filter = [DataciteRegisterJob]

--- a/spec/fixtures/files/mesh_terms.txt
+++ b/spec/fixtures/files/mesh_terms.txt
@@ -1,0 +1,26 @@
+*NEWRECORD
+RECTYPE = D
+MH = Sulfamerazine
+AQ = AA AD AE AG AI AN BL CF CH CL CS EC HI IM IP ME PD PK PO RE SD ST TO TU UR
+PRINT ENTRY = Methylsulfadiazine|T109|T121|NON|EQV|UNK (19XX)|760324|abbcdef
+ENTRY = Mebacid|T109|T121|TRD|NRW|UNK (19XX)|821123|abbcdef
+ENTRY = Trimetox|T109|TRD|NRW|DE|060410|abcdef
+MN = D02.065.884.725.853
+MN = D02.092.146.807.853
+MN = D02.886.590.700.725.853
+PA = Anti-Bacterial Agents
+MH_TH = BAN (19XX)
+MH_TH = FDA SRS (2014)
+MH_TH = INN (19XX)
+MH_TH = USP (19XX)
+ST = T109
+ST = T121
+N1 = Benzenesulfonamide, 4-amino-N-(4-methyl-2-pyrimidinyl)-
+RN = UR1SAB295F
+RR = 127-79-7 (Sulfamerazine)
+MS = A sulfanilamide that is used as an antibacterial agent.
+MR = 20160701
+DA = 19990101
+DC = 1
+DX = 19660101
+UI = D013416

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Etd do
+RSpec.describe Etd, :clean do
   subject(:etd) { FactoryGirl.build(:etd) }
 
   it_behaves_like 'a model with hyrax basic metadata', except: :keyword
@@ -55,6 +55,10 @@ RSpec.describe Etd do
 
   describe '#date_uploaded' do
     let(:time) { DateTime.current }
+
+    before do
+      AdminSet.find_or_create_default_admin_set_id
+    end
 
     it 'is a DateTime' do
       expect { etd.date_uploaded = time }

--- a/spec/support/mesh_helper.rb
+++ b/spec/support/mesh_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+module MeshHelper
+  def import_mesh_terms
+    m = Qa::Authorities::MeshTools::MeshImporter.new
+    File.open(file_fixture('mesh_terms.txt')) do |f|
+      m.import_from_file(f)
+    end
+  end
+end


### PR DESCRIPTION
This PR changes the subject field to use MeSH terms for
autocompletion. The MeSH terms need to be installed on the
server using these instructions:

https://github.com/samvera/questioning_authority#medical-subject-headings-mesh

You will need to run `rake db:migate` after pulling in this commit.

MeSH will require additional work so that Fedora stores the ID and
not the label. That is now issue #190.

Closes #124