### PR TITLE
adding hyrax basic metadata create and show to shared examples and os…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,8 @@ Metrics/BlockLength:
 RSpec/MultipleExpectations:
   Exclude:
     - 'spec/features/**/*'
+    - 'spec/support/shared_examples/hyrax_basic_metadata.rb'
 RSpec/ExampleLength:
   Exclude:
     - 'spec/features/**/*'
+    - 'spec/support/shared_examples/hyrax_basic_metadata.rb'

--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -4,8 +4,7 @@ module Hyrax
     SINGLE_VALUE = [:degree, :school, :department].freeze
 
     self.model_class = ::Etd
-    self.terms += [:degree, :date, :date_label, :department, :institution,
-                   :orcid_id, :resource_type, :rights_note, :school]
+    self.terms += [:degree, :date, :date_label, :department, :institution, :orcid_id, :resource_type, :rights_note, :school]
 
     ##
     # @return [Boolean]

--- a/spec/factories/etds.rb
+++ b/spec/factories/etds.rb
@@ -61,9 +61,8 @@ FactoryBot.define do
       school           ['School of Hattifattener Studies']
       source           ['Too-Ticky', 'Snufkin']
       subject          ['Moomins', 'Snorks']
-      resource_type    ['thesis']
-      rights_note      ['For the exclusive viewing of Little My.',
-                        'Moomin: do not read this.']
+      resource_type    ['Thesis']
+      rights_note      ['For the exclusive viewing of Little My.', 'Moomin: do not read this.']
       rights_statement [RDF::URI('http://rightsstatements.org/vocab/NKC/1.0/')]
     end
 


### PR DESCRIPTION
…hu etd create feature

I'm not sure this is quite ready but I think it's the right approach overall and want feedback, so am submitting. There are two TODOs left in the shared example (date_created and based_near), need feedback on how to handle them. Fixes #166 