### PR TITLE
adding the complete set of metadata to create and show feature spec

### DIFF
--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -4,8 +4,7 @@ module Hyrax
     SINGLE_VALUE = [:degree, :school, :department].freeze
 
     self.model_class = ::Etd
-    self.terms += [:degree, :date, :date_label, :department, :institution,
-                   :orcid_id, :resource_type, :rights_note, :school]
+    self.terms += [:degree, :date, :date_label, :department, :institution, :orcid_id, :resource_type, :rights_note, :school]
 
     ##
     # @return [Boolean]

--- a/spec/factories/etds.rb
+++ b/spec/factories/etds.rb
@@ -43,6 +43,7 @@ FactoryBot.define do
     end
 
     factory :moomins_thesis do
+      title            ['Moomintroll']
       creator          ['Moomin', 'Hemulen']
       date             ['199?']
       date_created     [Date.parse('2016-12-25')]
@@ -61,9 +62,8 @@ FactoryBot.define do
       school           ['School of Hattifattener Studies']
       source           ['Too-Ticky', 'Snufkin']
       subject          ['Moomins', 'Snorks']
-      resource_type    ['thesis']
-      rights_note      ['For the exclusive viewing of Little My.',
-                        'Moomin: do not read this.']
+      resource_type    ['Thesis']
+      rights_note      ['For the exclusive viewing of Little My.', 'Moomin: do not read this.']
       rights_statement [RDF::URI('http://rightsstatements.org/vocab/NKC/1.0/')]
     end
 


### PR DESCRIPTION
Fixes #166 

This commit audits the metadata used to create an OSHU Etd, by creating an Etd with a complete set of the displayable metadata and visiting its show page to confirm it.