### PR TITLE
testing create and show feature with full metadata

### DIFF
--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -1,18 +1,9 @@
 # frozen_string_literal: true
 module Hyrax
   class EtdForm < Hyrax::Forms::WorkForm
-    SINGLE_VALUE = [:degree, :school, :department].freeze
-
+    include SingleValuedForm
+    self.single_valued_fields = [:degree, :school, :department, :institution].freeze
     self.model_class = ::Etd
-    self.terms += [:degree, :date, :date_label, :department, :institution,
-                   :orcid_id, :resource_type, :rights_note, :school]
-
-    ##
-    # @return [Boolean]
-    # @see Hyrax::Forms::WorkForm#multiple?
-    def multiple?(field)
-      return false if SINGLE_VALUE.include?(field)
-      super
-    end
+    self.terms += [:degree, :date, :date_label, :department, :institution, :orcid_id, :resource_type, :rights_note, :school]
   end
 end

--- a/app/forms/single_valued_form.rb
+++ b/app/forms/single_valued_form.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+module SingleValuedForm
+  extend ActiveSupport::Concern
+  included do
+    class_attribute :single_valued_fields
+    self.single_valued_fields = []
+
+    def multiple?(field)
+      if single_valued_fields.include?(field.to_sym)
+        false
+      else
+        super
+      end
+    end
+
+    def [](key)
+      return Array(super).first if single_valued_fields.include?(key.to_sym)
+      super
+    end
+
+    def initialize_field(key)
+      return if single_valued_fields.include?(key.to_sym)
+      super
+    end
+  end
+
+  class_methods do
+    def multiple?(field)
+      if single_valued_fields.include?(field.to_sym)
+        false
+      else
+        super
+      end
+    end
+
+    def model_attributes(form_params)
+      super.tap do |params|
+        single_valued_fields.each do |field|
+          if params.key?(field) || params.key?(field.to_s)
+            params[field.to_s] = Array.wrap(params[field.to_s])
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/etds.rb
+++ b/spec/factories/etds.rb
@@ -43,27 +43,30 @@ FactoryBot.define do
     end
 
     factory :moomins_thesis do
+      title            ['Moomintroll']
       creator          ['Moomin', 'Hemulen']
       date             ['199?']
+      publisher        ['A Publisher']
       date_created     [Date.parse('2016-12-25')]
       date_label       ['Winter in Moomin Valley']
       date_modified    DateTime.current
       date_uploaded    DateTime.current
-      degree           ['M.Phil.']
-      department       ['Coin Collecting']
+      degree           ['D.N.P.']
+      department       ['Department of Biochemistry']
       description      ['Winter', 'Collecting']
       identifier       ['Moomin_123']
-      institution      ['Moomin Valley Community College']
+      institution      ['OHSU']
       keyword          ['moomin', 'snork', 'hattifattener']
       language         ['Finnish', 'Swedish']
       license          [RDF::URI('https://creativecommons.org/licenses/by-sa/4.0/')]
       orcid_id         ['0000-0001-2345-6789', '0000-0002-1825-0097']
-      school           ['School of Hattifattener Studies']
+      school           ['School of Public Health']
+      related_url      ['http://samvera.github.io']
       source           ['Too-Ticky', 'Snufkin']
       subject          ['Moomins', 'Snorks']
-      resource_type    ['thesis']
-      rights_note      ['For the exclusive viewing of Little My.',
-                        'Moomin: do not read this.']
+      resource_type    ['Thesis']
+      bibliographic_citation ['something cited']
+      rights_note      ['For the exclusive viewing of Little My.', 'Moomin: do not read this.']
       rights_statement [RDF::URI('http://rightsstatements.org/vocab/NKC/1.0/')]
     end
 

--- a/spec/features/edit_etd_spec.rb
+++ b/spec/features/edit_etd_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.feature 'Edit an OSHU ETD', :clean, js: false do
+  let(:admin) { FactoryBot.create(:admin) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:etd) do
+    FactoryBot.create(
+      :moomins_thesis,
+      user: admin,
+      visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    )
+  end
+  after { logout }
+  context 'an admin user' do
+    before do
+      login_as admin
+      AdminSet.find_or_create_default_admin_set_id
+    end
+    scenario 'can edit an Etd' do
+      visit "concern/etds/#{etd.id}"
+      click_link 'Edit'
+
+      new_title   = 'Finn Family Moomintroll'
+      new_keyword = 'moomin'
+
+      fill_in 'Title',   with: new_title
+      fill_in 'Keyword', with: new_keyword
+      find('#with_files_submit').click
+
+      expect(page).to have_content(new_title, new_keyword)
+    end
+  end
+
+  context "a non-admin user" do
+    before do
+      login_as user
+    end
+    scenario "cannot edit a work" do
+      visit "/concern/etds/#{etd.id}"
+      expect(page).not_to have_content('Edit')
+      visit "/concern/etds/#{etd.id}/edit"
+      expect(page).to have_content('Unauthorized')
+    end
+  end
+end

--- a/spec/forms/single_valued_form_spec.rb
+++ b/spec/forms/single_valued_form_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe SingleValuedForm do
+  subject(:etd) { TestForm.new(work, nil, nil) }
+  let(:work) { FactoryBot.build :etd }
+
+  before do
+    class TestForm < Hyrax::Forms::WorkForm
+      include SingleValuedForm
+    end
+    TestForm.single_valued_fields = [:degree]
+    TestForm.model_class = ::Etd
+    TestForm.terms = [:degree, :title]
+  end
+
+  after do
+    Object.send(:remove_const, :TestForm)
+  end
+
+  context "an instance" do
+    it "reports multiple-valued fields" do
+      expect(etd.multiple?(:title)).to be true
+    end
+    it "reports single-valued fields" do
+      expect(etd.multiple?(:degree)).to be false
+    end
+  end
+
+  context "the class" do
+    it "reports multiple-valued fields" do
+      expect(TestForm.multiple?(:title)).to be true
+    end
+    it "reports single-valued fields" do
+      expect(TestForm.multiple?(:degree)).to be false
+    end
+  end
+
+  describe "model_attributes" do
+    let(:params) { ActionController::Parameters.new(degree: 'D.N.P.') }
+    let(:attribs) { TestForm.model_attributes(params).to_h }
+
+    it "converts singular fields to arrays" do
+      expect(attribs[:degree]).to eq(['D.N.P.'])
+    end
+  end
+end


### PR DESCRIPTION
Fixes #166

This commit audits the metadata used to create an OSHU Etd, by creating an Etd with a complete set of the displayable metadata and visiting its show page to confirm it. It also separates the edit spec into its own file, which takes advantage of the database cleaning that occurs between rspec suites and is easier to manage. It also fixes a bug uncovered by the feature spec, in which single-valued fields were sent to the back end as strings, which meant they were considered unpermitted parameters by the hyrax gem. The fix wraps single-value inputs in arrays, and was first implemented in Laevigata.