### PR TITLE
only admins can delete Etds

### DIFF
--- a/spec/features/delete_an_etd_spec.rb
+++ b/spec/features/delete_an_etd_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.feature 'Delete an OSHU ETD', js: false do
+  let(:admin) { FactoryBot.create(:admin) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:etd) do
+    FactoryBot.create(
+      :moomins_thesis,
+      user: admin,
+      visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    )
+  end
+
+  context 'an admin user' do
+    before do
+      login_as admin
+      AdminSet.find_or_create_default_admin_set_id
+    end
+
+    after { logout }
+
+    scenario 'can delete an OSHU Etd' do
+      visit "concern/etds/#{etd.id}"
+
+      click_on('Delete', match: :first)
+
+      expect(page).to have_content("Deleted #{etd.title.first}")
+    end
+  end
+
+  # Non admin users should not be able to delete an OSHU Etd
+
+  context "a non-admin user" do
+    before do
+      login_as user
+    end
+
+    after { logout }
+
+    scenario "cannot delete an OSHU Etd" do
+      expect(user.admin?).to eq(false)
+      visit "concern/etds/#{etd.id}"
+      expect(page).not_to have_content('Delete')
+    end
+  end
+
+  context "a non-authenticated user" do
+    scenario "cannot delete an OSHU Etd" do
+      # non-authenticated user can view public OSHU Etd
+      visit "concern/etds/#{etd.id}"
+      expect(page).to have_content etd.title.first.to_s
+      # but cannot delete it
+      expect(page).not_to have_content('Delete')
+    end
+  end
+end


### PR DESCRIPTION
This commit uses feature tests to confirm that both authenticated and unauthenticated users do not have the ability to delete an Etd, but admins do. Fixes #48.