### PR TITLE
Remove Hyrax branding from locale

### DIFF
--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -63,16 +63,16 @@ en:
         rights_statement: Rights
         description:      Description
   hyrax:
-    product_name:           "Hyrax"
-    product_twitter_handle: "@SamveraRepo"
-    institution_name:       "Institution"
-    institution_name_full:  "The Institution Name"
-    account_name:           "My Institution Account Id"
+    product_name:           "OHSU Scholar Archive"
+    product_twitter_handle:
+    institution_name:       "OHSU"
+    institution_name_full:  "OHSU"
+    account_name:
     directory:
-      suffix:               "@example.org"
+      suffix:
     footer:
-      copyright_html: "<strong>Copyright &copy; 2017 Samvera</strong> Licensed under the Apache License, Version 2.0"
-      service_html: A service of <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.
+      copyright_html:
+      service_html:
     admin:
       sidebar:
         sidekiq: "Sidekiq"

--- a/spec/features/access_etd_spec.rb
+++ b/spec/features/access_etd_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'Access an Etd', js: false do
     scenario 'searching submitted public etd' do
       visit '/'
 
-      fill_in 'Search Hyrax', with: etd.first_title
+      fill_in 'Search OHSU Scholar Archive', with: etd.first_title
       click_button 'Go'
 
       within(:css, "li#document_#{etd.id}") do
@@ -37,7 +37,7 @@ RSpec.feature 'Access an Etd', js: false do
     scenario 'searching private etd is restricted' do
       visit '/'
 
-      fill_in 'Search Hyrax', with: private_etd.first_title
+      fill_in 'Search OHSU Scholar Archive', with: private_etd.first_title
       click_button 'Go'
 
       expect(page).not_to have_css("li#document_#{private_etd.id}")
@@ -71,7 +71,7 @@ RSpec.feature 'Access an Etd', js: false do
     scenario 'searching institutional etd is restricted' do
       visit '/'
 
-      fill_in 'Search Hyrax', with: institutional_etd.first_title
+      fill_in 'Search OHSU Scholar Archive', with: institutional_etd.first_title
       click_button 'Go'
 
       expect(page).not_to have_css("li#document_#{institutional_etd.id}")


### PR DESCRIPTION
This commit replaces the Hyrax branding text with OSHU
information.

Closes #207 