### PR TITLE
adds admin set back after clean removes it

### DIFF
--- a/spec/features/autocomplete_mesh_spec.rb
+++ b/spec/features/autocomplete_mesh_spec.rb
@@ -2,11 +2,13 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.feature 'Autocomplete MeSH terms', :clean, mesh: true, js: true do
+RSpec.feature 'Autocomplete MeSH terms', mesh: true, js: true do
   let(:admin) { FactoryBot.create(:admin) }
   before do
     import_mesh_terms
     login_as admin
+    ActiveFedora::Cleaner.clean!
+    AdminSet.find_or_create_default_admin_set_id
   end
 
   scenario 'autocompleting MeSH terms in the subject field on form' do
@@ -42,5 +44,7 @@ RSpec.feature 'Autocomplete MeSH terms', :clean, mesh: true, js: true do
     expect(page).to have_content 'Sulfamerazine'
     expect(page).to have_content 'MeSH Test'
     expect(page).to have_content 'In Copyright'
+    Etd.where(title_tesim: 'MeSH Test').first.delete
+    expect(Etd.all.size).to eq 0
   end
 end

--- a/spec/features/edit_etd_spec.rb
+++ b/spec/features/edit_etd_spec.rb
@@ -35,7 +35,6 @@ RSpec.feature 'Edit an OSHU ETD', :clean, js: true do
       fill_in 'Description', with: etd[:description].first
       # term for license URI set in factory
       select('Creative Commons BY-SA Attribution-ShareAlike 4.0 International', from: 'License')
-      fill_in 'Publisher', with: etd[:publisher].first
       fill_in 'Date Created', with: etd[:date_created].first
       fill_in 'Subject', with: etd[:subject].first
       fill_in 'Language', with: etd[:language].first


### PR DESCRIPTION
in autocomplete feature spec, as well as deleting Etd created inline, in the test that creates it. More manual, but very explicit.