### PR TITLE
Improve capistrano deploy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,9 @@ Metrics/BlockLength:
     - '**/*.gemspec' # these would normally be inherited from bixby
     - 'config/**/*'
     - '**/*/catalog_controller.rb'
+Rails/TimeZone:
+  Exclude:
+    - 'config/initializers/git_sha.rb'
 RSpec/MultipleExpectations:
   Exclude:
     - 'spec/features/**/*'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,6 +2,9 @@
 # config valid for current version and patch releases of Capistrano
 lock "~> 3.10.0"
 
+# Restart options
+set :passenger_restart_wait, 60
+
 set :application, "mahonia"
 set :repo_url, "https://github.com/curationexperts/mahonia.git"
 
@@ -24,3 +27,11 @@ append :linked_dirs, "public/assets"
 append :linked_files, "config/database.yml"
 append :linked_files, "config/secrets.yml"
 append :linked_files, ".env.production"
+
+# Passenger is not consistently restarting, but the problem seems to
+# be fixed by making it restart twice.
+task :reenable_deploy_restart do
+  ::Rake.application['passenger:restart'].reenable
+  ::Rake.application['passenger:restart']
+end
+after 'deploy:restart', 'reenable_deploy_restart'

--- a/config/initializers/git_sha.rb
+++ b/config/initializers/git_sha.rb
@@ -21,7 +21,7 @@ BRANCH =
 LAST_DEPLOYED =
   if Rails.env.production? && File.exist?(revisions_logfile)
     deployed = `tail -1 #{revisions_logfile}`.chomp.split(" ")[7]
-    Date.parse(deployed).strftime("%d %B %Y")
+    DateTime.parse(deployed).strftime("%e %b %Y %H:%M:%S")
   else
     "Not in deployed environment"
   end


### PR DESCRIPTION
1. Timestamp the deploy so it's easier to tell when the latest
code was deployed and whether passenger has restarted
2. Restart passenger twice and add a time delay.