### PR TITLE
Revert "editing date field, predicate is now verbatimEventDate and label is 'EDTF Date'"

### DIFF
--- a/app/models/schemas/core_metadata.rb
+++ b/app/models/schemas/core_metadata.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Schemas
   class CoreMetadata < ActiveTriples::Schema
-    property :date,        predicate: RDF::Vocab::DWC.verbatimEventDate
+    property :date,        predicate: RDF::Vocab::DC11.date
     property :date_label,  predicate: RDF::Vocab::DWC.verbatimEventDate
     property :keyword,     predicate: RDF::Vocab::SCHEMA.keywords
     property :rights_note, predicate: RDF::Vocab::DC11.rights

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -17,7 +17,6 @@ en:
           based_near_tesim: Location
           contributor_tesim: Contributor
           creator_tesim: Creator
-          date: EDTF Date
           date_created_tesim: Date Created
           date_modified_dtsi: Date Modified
           date_uploaded_dtsi: Date Uploaded
@@ -35,7 +34,6 @@ en:
           based_near_tesim: Location
           contributor_tesim: Contributor
           creator_tesim: Creator
-          date: EDTF Date
           date_created_tesim: Date Created
           date_modified_dtsi: Date Modified
           date_uploaded_dtsi: Date Uploaded
@@ -61,7 +59,6 @@ en:
         orcid_id:         ORCID
         rights_statement: Rights
         description:      Description
-        date:             EDTF Date
   hyrax:
     product_name:           "OHSU Scholar Archive"
     product_twitter_handle:

--- a/spec/features/edit_etd_spec.rb
+++ b/spec/features/edit_etd_spec.rb
@@ -35,6 +35,7 @@ RSpec.feature 'Edit an OSHU ETD', :clean, js: true do
       fill_in 'Description', with: etd[:description].first
       # term for license URI set in factory
       select('Creative Commons BY-SA Attribution-ShareAlike 4.0 International', from: 'License')
+      fill_in 'Publisher', with: etd[:publisher].first
       fill_in 'Date Created', with: etd[:date_created].first
       fill_in 'Subject', with: etd[:subject].first
       fill_in 'Language', with: etd[:language].first

--- a/spec/support/shared_examples/core_metadata.rb
+++ b/spec/support/shared_examples/core_metadata.rb
@@ -2,7 +2,7 @@
 RSpec.shared_examples 'a model with ohsu core metadata' do
   subject(:model) { described_class.new }
 
-  it { is_expected.to have_editable_property(:date,        RDF::Vocab::DWC.verbatimEventDate) }
+  it { is_expected.to have_editable_property(:date,        RDF::Vocab::DC11.date) }
   it { is_expected.to have_editable_property(:date_label,  RDF::Vocab::DWC.verbatimEventDate) }
   it { is_expected.to have_editable_property(:description, RDF::Vocab::DC11.description) }
   it { is_expected.to have_editable_property(:keyword,     RDF::Vocab::SCHEMA.keywords) }

--- a/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'hyrax/base/_form_metadata.html.erb', type: :view do
       expect(page)
         .to have_multivalued_field(:date)
         .on_model(work.class)
-        .with_label 'EDTF Date'
+        .with_label 'Date'
     end
 
     it 'has date labels' do

--- a/spec/views/hyrax/base/_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_metadata.html.erb_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'hyrax/base/_metadata.html.erb', type: :view do
   it { is_expected.to have_show_field(:creator).with_values(*work.creator).and_label('Creator') }
   # underspecify date values (they aren't necessarily sensible for all Date/DateTime values)
   it { is_expected.to have_show_field(:date_created).with_label('Date created') }
-  it { is_expected.to have_show_field(:date).with_values(*work.date).and_label('EDTF Date') }
+  it { is_expected.to have_show_field(:date).with_values(*work.date).and_label('Date') }
   it { is_expected.to have_show_field(:date_label).with_values(*work.date_label).and_label('Date label') }
   it { is_expected.to have_show_field(:degree).with_values(*work.degree).and_label('Degree Name') }
   it { is_expected.to have_show_field(:department).with_values(*work.department).and_label('Department') }


### PR DESCRIPTION
The predicate was correct before, we need a follow up to reinstate the new
label.

This reverts commit 8598f9ef71bace7275dc66f65c60cba212f7b208.