### PR TITLE
Fix for broken markup when certain locale strings are empty

### DIFF
--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -64,15 +64,15 @@ en:
         date:             EDTF Date
   hyrax:
     product_name:           "OHSU Scholar Archive"
-    product_twitter_handle:
+    product_twitter_handle: ""
     institution_name:       "OHSU"
     institution_name_full:  "OHSU"
-    account_name:
+    account_name: ""
     directory:
-      suffix:
+      suffix: ""
     footer:
-      copyright_html:
-      service_html:
+      copyright_html: ""
+      service_html: ""
     admin:
       sidebar:
         sidekiq: "Sidekiq"


### PR DESCRIPTION
This fixes a problem where certain elements in the footer and
header look broken if the locale string is left blank instead
of being an empty string.
  
Closes #219 