### PR TITLE
possible approach for disabling hyrax metadata inputs

### DIFF
--- a/app/assets/stylesheets/mahonia.scss
+++ b/app/assets/stylesheets/mahonia.scss
@@ -1,1 +1,2 @@
 @import 'mahonia/search_fields';
+@import 'mahonia/disabled_hyrax_metadata';

--- a/app/assets/stylesheets/mahonia/_disabled_hyrax_metadata.scss
+++ b/app/assets/stylesheets/mahonia/_disabled_hyrax_metadata.scss
@@ -1,0 +1,3 @@
+div.disabled_hyrax  {
+  display: none;
+}

--- a/app/inputs/disabled_hyrax_input.rb
+++ b/app/inputs/disabled_hyrax_input.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+class DisabledHyraxInput < MultiValueInput
+end

--- a/app/views/records/edit_fields/_publisher.html.erb
+++ b/app/views/records/edit_fields/_publisher.html.erb
@@ -1,0 +1,6 @@
+<%= f.input :publisher,
+            as: :disabled_hyrax,
+            input_html: {
+              class: 'form-control'
+            },
+            required: f.object.required?(:publisher) %>


### PR DESCRIPTION
@no-reply @little9 - what do you two think about doing this to prevent Hyrax core metadata fields that we don't want from appearing? We need to file a Hyrax bug about it, but this seems to me our quickest, clean and easy-to-revert way to get it taken care of here and now. 