### PR TITLE
remove Publisher from Hyrax Form's terms

### DIFF
--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -4,6 +4,8 @@ module Hyrax
     include SingleValuedForm
     self.single_valued_fields = [:degree, :school, :department, :institution].freeze
     self.model_class = ::Etd
+
+    Mahonia::Terms.remove_terms.each { |term| terms.delete(term) }
     self.terms += [:degree, :date, :date_label, :department, :institution, :orcid_id, :resource_type, :rights_note, :school]
   end
 end

--- a/app/lib/mahonia/terms.rb
+++ b/app/lib/mahonia/terms.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+module Mahonia
+  class Terms
+    REMOVE_TERMS = [:publisher].freeze
+    def self.remove_terms
+      REMOVE_TERMS
+    end
+  end
+end

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -21,6 +21,17 @@ RSpec.feature 'Create an OSHU ETD', :clean, js: false do
       AdminSet.find_or_create_default_admin_set_id
     end
 
+    scenario 'the form will not contain unwanted fields', :perform_enqueued, :datacite_api, js: true do
+      ActiveJob::Base.queue_adapter.filter = [DataciteRegisterJob]
+
+      visit("/concern/etds/new")
+
+      expect(page).to have_content 'Add New Etd'
+      click_link 'Additional fields'
+
+      expect(page).not_to have_content('Publisher')
+    end
+
     scenario 'can create an Etd', :perform_enqueued, :datacite_api do
       ActiveJob::Base.queue_adapter.filter = [DataciteRegisterJob]
 


### PR DESCRIPTION
This commit removes the "publisher" Form term inherited from the Hyrax Form, which is the last step in removing all of the occurrences of this Hyrax metadata property that OHSU doesn't want.