### PR TITLE
Remove `:publisher` term from the Etd model

### DIFF
--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -5,7 +5,7 @@ module Hyrax
     self.single_valued_fields = [:degree, :school, :department, :institution].freeze
     self.model_class = ::Etd
 
-    Mahonia::Terms.remove_terms.each { |term| terms.delete(term) }
+    model_class::EXCLUDED_TERMS.each { |term| terms.delete(term) }
     self.terms += [:degree, :date, :date_label, :department, :institution, :orcid_id, :resource_type, :rights_note, :school]
   end
 end

--- a/app/lib/mahonia/terms.rb
+++ b/app/lib/mahonia/terms.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-module Mahonia
-  class Terms
-    REMOVE_TERMS = [:publisher].freeze
-    def self.remove_terms
-      REMOVE_TERMS
-    end
-  end
-end

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -2,6 +2,8 @@
 class Etd < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
 
+  EXCLUDED_TERMS = [:publisher].freeze
+
   self.indexer = EtdIndexer
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []
@@ -15,6 +17,10 @@ class Etd < ActiveFedora::Base
 
   apply_schema Schemas::CoreMetadata, Schemas::GeneratedResourceSchemaStrategy.new
   apply_schema Schemas::EtdMetadata,  Schemas::GeneratedResourceSchemaStrategy.new
+
+  EXCLUDED_TERMS.each do |term|
+    Schemas::GeneratedResourceSchemaStrategy.new.delete(self, term)
+  end
 
   ##
   # @param id [String]

--- a/app/models/schemas/generated_resource_schema_strategy.rb
+++ b/app/models/schemas/generated_resource_schema_strategy.rb
@@ -9,10 +9,34 @@ module Schemas
     def apply(object, property)
       result = super
 
-      klass = object.instance_variable_get(:@generated_resource_class)
+      klass = class_for(object: object)
       return result unless klass
+
       klass.property property.name, property.to_h
       result
     end
+
+    ##
+    # Delete a property.
+    #
+    # @param object        [Class]
+    # @param property_name [#to_s]
+    #
+    # @return [void]
+    def delete(object, property_name)
+      property_name = property_name.to_s
+
+      object.properties.delete(property_name) &&
+        object.attribute_names.delete(property_name) &&
+        object.delegated_attributes.delete(property_name)
+
+      class_for(object: object)&.properties&.delete(property_name)
+    end
+
+    private
+
+      def class_for(object:)
+        object.instance_variable_get(:@generated_resource_class)
+      end
   end
 end

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -4,9 +4,13 @@ require 'rails_helper'
 RSpec.describe Etd, :clean do
   subject(:etd) { FactoryGirl.build(:etd) }
 
-  it_behaves_like 'a model with hyrax basic metadata', except: :keyword
+  it_behaves_like 'a model with hyrax basic metadata', except: [:keyword, :publisher]
   it_behaves_like 'a model with ohsu core metadata'
   it_behaves_like 'a model with ohsu ETD metadata'
+
+  describe 'excluded properties' do
+    it { expect(described_class.properties).not_to include 'publisher' }
+  end
 
   describe 'an attached pdf' do
     let(:actor)  { Hyrax::Actors::FileSetActor.new(FileSet.create, user) }


### PR DESCRIPTION
We had previously disabled `:publisher` on the form and views only. This removes
it at the model layer.

Unfortunately, `ActiveFedora` needs us to remove this from multiple `properties`
and `attributes` data structures, which all need to be syncrhonized. To do this
cleanly, we have added a `Schemas::GeneratedResourceSchemaStrategy#delete`
method. Ideally, this behavior would be pushed into `ActiveFedora` and some of
the synchronized data structures would be squashed out.