### PR TITLE
Add minimal tests for untested code

### DIFF
--- a/spec/channels/application_cable/channel_spec.rb
+++ b/spec/channels/application_cable/channel_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ApplicationCable::Channel do
+  it { expect(described_class).to be < ActionCable::Channel::Base }
+end

--- a/spec/channels/application_cable/connection_spec.rb
+++ b/spec/channels/application_cable/connection_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ApplicationCable::Connection do
+  it { expect(described_class).to be < ActionCable::Connection::Base }
+end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ApplicationMailer do
+  it { expect(described_class).to be < ActionMailer::Base }
+end

--- a/spec/models/qa_spec.rb
+++ b/spec/models/qa_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Qa do
+  describe '.table_name_prefix' do
+    it { expect(described_class.table_name_prefix).to end_with '_' }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,7 +22,7 @@ Capybara.register_driver :selenium do |app|
   Capybara::Selenium::Driver.new(app, browser: :chrome)
 end
 
-Capybara.javascript_driver = :selenium_chrome
+Capybara.javascript_driver = :selenium_chrome_headless
 
 Capybara.configure do |config|
   config.default_max_wait_time = 10 # seconds


### PR DESCRIPTION
Several modules don't actually get used during the test suite. Mainly, these
inherit directly from base Rails (or Samvera) classes and contain no custom
behavior. These tests manage to be both very minimal and overly strict, but
should help ensure these modules behave as expected.