### PR TITLE
Store MeSH URIs not labels in Fedora

### DIFF
--- a/app/actors/hyrax/actors/etd_actor.rb
+++ b/app/actors/hyrax/actors/etd_actor.rb
@@ -4,6 +4,33 @@
 module Hyrax
   module Actors
     class EtdActor < Hyrax::Actors::BaseActor
+      include Mahonia::MeshTermService
+
+      # Go through the subject attributes when creating and replace with URIs if appropriate
+      # @param [Hyrax::Actors::Environment]
+      def create(env)
+        uris_for_labels(env)
+        super
+      end
+
+      # Go through the subject attributes when updating and replace with URIs if appropriate
+      # @param [Hyrax::Actors::Environment]
+      def update(env)
+        uris_for_labels(env)
+        super
+      end
+
+      private
+
+        # Go through the subject attributes and replace with URIs if appropriate
+        # @param [Hyrax::Actors::Environment]
+        # @return [Boolean]
+        def uris_for_labels(env)
+          if env.attributes&.dig(:subject)
+            env.attributes[:subject] = labels_to_uris(env.attributes.dig(:subject))
+          end
+          true
+        end
     end
   end
 end

--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -2,6 +2,7 @@
 module Hyrax
   class EtdForm < Hyrax::Forms::WorkForm
     include SingleValuedForm
+    include Mahonia::MeshTermService
     self.single_valued_fields = [:degree, :school, :department, :institution].freeze
     self.model_class = ::Etd
 

--- a/app/lib/mahonia/mesh_term_service.rb
+++ b/app/lib/mahonia/mesh_term_service.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+module Mahonia
+  module MeshTermService
+    # A service for returning data assocaited with MeSH terms
+    # the service includes methods for returning MeSH IDs and
+    # for getting MeSH terms from IDs. It also includes methods
+    # for transforming arrays of MeSH URIs into labels and
+    # vice versa. This is used in edit forms and show views
+    # so that we are storing MeSH URIs in Fedora, but users see
+    # them as MeSH labels/terms.
+    URI_PREFIX = 'https://id.nlm.nih.gov/mesh/'
+    ##
+    # @return [String] the URI without the id
+    def uri_prefix
+      URI_PREFIX
+    end
+
+    ##
+    # @param [String]
+    # @return [String] the label for a MeSH term ID
+    def label_from_id(id)
+      m = Qa::Authorities::Mesh.new
+      m.find(id)&.dig(:label)
+    end
+
+    ##
+    # @param [String]
+    # @return [String] the label for a complete MeSH term URI
+    def label_from_uri(uri)
+      id = uri.gsub(uri_prefix, '')
+      m = Qa::Authorities::Mesh.new
+      m.find(id)&.dig(:label)
+    end
+
+    ##
+    # @param [String]
+    # @return [String] The id for a MeSH label
+    def id_from_label(label)
+      m = Qa::Authorities::Mesh.new
+      return "Subject: #{label}" if m.search(label.downcase) == []
+      m.search(label.downcase).first[:id]
+    end
+
+    ##
+    # @param [Array<String>]
+    # @return [Array]  An array with URIs for MeSH terms, but plain strings for non-mesh terms
+    def labels_to_uris(labels)
+      labels.select { |label| !label.include?('Subject:') }
+      labels.map { |label| id_from_label(label).include?('Subject:') ? label : RDF::URI.intern("#{uri_prefix}#{id_from_label(label)}") }
+    end
+
+    ##
+    # @param [Array<String>]
+    # @return [Array] An array of labels from MeSH uris
+    def uris_to_labels(uris)
+      uris.map { |uri| label_from_id(uri.gsub(uri_prefix, '')) }
+    end
+
+    ##
+    # @param [ActiveFedora::Base]
+    # @return [Array] An array of labels for the edit view
+    def edit_subject_view(curation_concern)
+      curation_concern[:subject] = curation_concern[:subject].map { |subject| subject.is_a?(String) ? subject : label_from_uri(subject_id_or_string(subject)) }
+    end
+
+    private
+
+      ##
+      # @param [String, RDF::URI]
+      # @return [String] Return string for a subject, either itself as string or the id method
+      def subject_id_or_string(subject)
+        return subject.to_s if subject.try(:id).nil?
+        subject.id
+      end
+  end
+end

--- a/app/renderers/hyrax/renderers/subject_renderer.rb
+++ b/app/renderers/hyrax/renderers/subject_renderer.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+module Hyrax
+  module Renderers
+    class SubjectRenderer < AttributeRenderer
+      include Mahonia::MeshTermService
+
+      def li_value(value)
+        value = options[:value].first if value.is_a? Hash
+        if value.include?('https://id.nlm.nih.gov/mesh')
+          "#{link_to(label_from_uri(value), search_path(value))} <a target='_blank' href='#{value}'><span class='glyphicon glyphicon-new-window'></span></a>"
+        else
+          link_to(ERB::Util.h(value), search_path(value))
+        end
+      end
+
+      private
+
+        def search_path(value)
+          Rails.application.routes.url_helpers.search_catalog_path(:"f[#{search_field}][]" => value)
+        end
+
+        def search_field
+          ERB::Util.h(Solrizer.solr_name(options.fetch(:search_field, field), :facetable, type: :string))
+        end
+    end
+  end
+end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,7 +1,7 @@
 <%= presenter.attribute_to_html(:creator, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:orcid_id) %>
 <%= presenter.attribute_to_html(:contributor, render_as: :faceted) %>
-<%= presenter.attribute_to_html(:subject, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:subject, render_as: :subject) %>
 <%= presenter.attribute_to_html(:degree, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:department, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:institution, render_as: :faceted) %>

--- a/app/views/records/edit_fields/_subject.html.erb
+++ b/app/views/records/edit_fields/_subject.html.erb
@@ -1,3 +1,7 @@
+<% mesh_term = (Class.new{ include Mahonia::MeshTermService }).new %>
+<% if defined? curation_concern %>
+    <% mesh_term.edit_subject_view(curation_concern) %>
+<% end  %>
 <%= f.input key,
             as: :multi_value,
             input_html: {

--- a/spec/actors/hyrax/actors/etd_actor_spec.rb
+++ b/spec/actors/hyrax/actors/etd_actor_spec.rb
@@ -4,7 +4,30 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::Actors::EtdActor do
-  it "has tests" do
-    skip "Add your tests here"
+  subject(:actor)  { described_class.new(next_actor) }
+  let(:ability)    { Ability.new(user) }
+  let(:env)        { Hyrax::Actors::Environment.new(object, ability, {}) }
+  let(:next_actor) { Hyrax::Actors::Terminator.new }
+  let(:object)     { FactoryBot.create(:etd) }
+  let(:user)       { FactoryBot.build(:user) }
+
+  describe '#create' do
+    context do
+      before { ActiveJob::Base.queue_adapter = :test }
+
+      it 'processes the MeSH terms' do
+        expect { actor.create(env).to eq(true) }
+      end
+    end
+  end
+
+  describe '#update' do
+    context do
+      before { ActiveJob::Base.queue_adapter = :test }
+
+      it 'processes the MeSH terms for editing' do
+        expect { actor.create(env).to eq(true) }
+      end
+    end
   end
 end

--- a/spec/lib/mahonia/mesh_term_service_spec.rb
+++ b/spec/lib/mahonia/mesh_term_service_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Mahonia::MeshTermService, mesh: true do
+  subject(:mesh_term) { (Class.new { include Mahonia::MeshTermService }).new }
+  let(:label) { 'Sulfamerazine' }
+  let(:labels) { ['Sulfamerazine'] }
+  let(:id) { 'D013416' }
+  let(:uri) { 'https://id.nlm.nih.gov/mesh/D013416' }
+  let(:uris) { ['https://id.nlm.nih.gov/mesh/D013416'] }
+  let(:uri_prefix) { 'https://id.nlm.nih.gov/mesh/' }
+  let(:non_mesh_term) { 'Sumerian Grammar' }
+  let(:non_mesh_prefixed_term) { 'Subject: Sumerian Grammar' }
+  let(:mixed_labels) { ['Subject: Sumerian Grammar', 'Sulfamerazine'] }
+  let(:mixed_uris) { ['Subject: Sumerian Grammar', 'https://id.nlm.nih.gov/mesh/D013416'] }
+  let(:subject_uris) { { subject: [RDF::URI('https://id.nlm.nih.gov/mesh/D013416')] } }
+
+  before do
+    import_mesh_terms
+  end
+
+  describe '#uri_prefix' do
+    it 'returns the MeSH uri prefix' do
+      expect(mesh_term.uri_prefix).to eq(uri_prefix)
+    end
+  end
+
+  describe '#label_from_id' do
+    it 'returns a MeSH term as a label when given an ID' do
+      expect(mesh_term.label_from_id(id)).to eq(label)
+    end
+  end
+
+  describe '#label_from_uri' do
+    it 'returns a MeSH term as a label when given a URI' do
+      expect(mesh_term.label_from_uri(uri)).to eq(label)
+    end
+  end
+
+  describe '#id_from_label' do
+    it 'returns a MeSH id when given a label' do
+      expect(mesh_term.id_from_label(label)).to eq(id)
+    end
+
+    it 'returns a prefixed string when given a subject that is not a MeSH term' do
+      expect(mesh_term.id_from_label(non_mesh_term)).to eq(non_mesh_prefixed_term)
+    end
+  end
+
+  describe '#labels_to_uris' do
+    it 'returns an array of uris when given an array of labels' do
+      expect(mesh_term.labels_to_uris(labels)).to eq(uris)
+    end
+
+    it 'returns an array of uris and strings when given a mix of MeSH and non-MeSH terms' do
+      expect(mesh_term.labels_to_uris(mixed_labels)).to eq(mixed_uris)
+    end
+  end
+
+  describe '#uris_to_labels' do
+    it 'returns an array of uris when given an array of labels' do
+      expect(mesh_term.uris_to_labels(uris)).to eq(labels)
+    end
+  end
+
+  describe '#uris_to_labels' do
+    it 'returns an array of labels when given a hash with a subject param with uris' do
+      expect(mesh_term.edit_subject_view(subject_uris)).to eq(labels)
+    end
+  end
+end

--- a/spec/renderers/hyrax/renderers/subject_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/subject_renderer_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Hyrax::Renderers::SubjectRenderer, mesh: true do
+  let(:field) { :subject }
+  let(:renderer) { described_class.new(field, ['https://id.nlm.nih.gov/mesh/D013416']) }
+  let(:markup) { subject }
+  before do
+    import_mesh_terms
+  end
+
+  describe "#attribute_to_html" do
+    subject { Nokogiri::HTML(renderer.render) }
+
+    let(:expected) { Nokogiri::HTML(tr_value) }
+
+    let(:tr_value) do
+      # rubocop:disable Metrics/LineLength
+      "<tr><th>Subject</th>\n<td><ul class='tabular'><li itemprop=\"about\" itemscope itemtype=\"http://schema.org/Thing\" class=\"attribute subject\"><span itemprop=\"name\"><a href=\"/catalog?f%5Bsubject_sim%5D%5B%5D=https%3A%2F%2Fid.nlm.nih.gov%2Fmesh%2FD013416\">Sulfamerazine</a> <a target='_blank' href='https://id.nlm.nih.gov/mesh/D013416'><span class='glyphicon glyphicon-new-window'></span></a></span></li></ul></td></tr>"
+    end
+
+    it { expect(markup).to be_equivalent_to(expected) }
+  end
+end


### PR DESCRIPTION
This commit introduces a MeshTerm service that transforms
MeSH labels into URIs and vice versa. This is used so that
users can search and select MeSH terms in the UI, with the
application storing MeSH URIs in Fedora on the back end. Since
the subject field can be used for non-MeSH terms, the service
can distinguish between MeSH terms and non-MeSH subjects and
processes them appropriately. The MeSH term service is used in the
`EtdActor` in the `create` and `update` methods.

Since MeSH URIs are stored on the back end, this also
introduces a subject renderer to display the label in the show
view. The renderer has a link for the MeSH URI that will open
a new tab when the user clicks on it, along with the label.

Closes #190 
Closes #218 