### PR TITLE
adjusting flow of edit feature test in hopes of more consistent relia…

### DIFF
--- a/spec/features/edit_etd_spec.rb
+++ b/spec/features/edit_etd_spec.rb
@@ -95,10 +95,10 @@ RSpec.feature 'Edit an OSHU ETD', :clean, js: true do
         attach_file('files[]', "#{fixture_path}/files/pdf-sample.pdf", visible: false, wait: 10)
       end
 
+      expect(find('#with_files_submit')).not_to be_disabled
       click_on('Save')
-      # wait until we have a record
-      persisted_etd = Etd.where(title: "Edited Title") while persisted_etd.nil?
 
+      sleep(2)
       expect(page).to have_content "Edited Title"
       expect(page).to have_content "Edited Creator"
       expect(page).to have_content "Edited Keyword"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,7 +22,7 @@ Capybara.register_driver :selenium do |app|
   Capybara::Selenium::Driver.new(app, browser: :chrome)
 end
 
-Capybara.javascript_driver = :selenium_chrome
+Capybara.javascript_driver = :selenium_chrome_headless
 
 Capybara.configure do |config|
   config.default_max_wait_time = 10 # seconds


### PR DESCRIPTION
…bility

This test removes a means for waiting until the Etd that we want to use to test editing had been persisted, because it proved a hindrance to the normal flow of events, ie, the show page being automatically loaded after submitting the create form. It goes back to employing a sleep of 2 seconds to make the test wait for the browser to get to that state. 