### PR TITLE
preparing to deploy new features: add import rake task and set asset compile to true in production env

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,7 +24,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+namespace :import do
+  desc 'Run sample import of bepress fixture csv'
+  task import_sample_records: :environment do
+    parser = MahoniaCsvParser.new(file: File.open('spec/fixtures/bepress_etd_sample.csv'))
+    Importer.new(parser: parser).import
+    first = Etd.where(title: "Representations and Circuits for Time Based Computation").first.id
+    second = Etd.where(title: "Dielectric functions and optical bandgaps of high-K dielectrics by far ultraviolet spectroscopic ellipsometry").first.id
+    third = Etd.where(title: "Laser  Processing  Optimization for Semiconductor Based Devices").first.id
+    p "Successfully created three Etds, with these ids: #{first}, #{second}, #{third}"
+  end
+end


### PR DESCRIPTION
These commits add a rake task to import our sample bepress csv, outputting the ids of the Etds created for demoing, and set the production config.asset_compile to true (we'd found an error deploying an OHSU sprite earlier that this commit helps address).