### PR TITLE
Introduce a generic `mahonia:import:bepress_csv` task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ end
 ruby '~> 2.4.2'
 
 # DCE importer
-gem 'darlingtonia', '0.1.1'
+gem 'darlingtonia', '0.2.0'
 gem 'dotenv-rails'
 gem 'honeybadger', '~> 3.1'
 gem 'hydra-role-management'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ GEM
     csl-styles (1.0.1.8)
       csl (~> 1.0)
     daemons (1.2.5)
-    darlingtonia (0.1.1)
+    darlingtonia (0.2.0)
       active-fedora (>= 11.0, <= 12.99)
     database_cleaner (1.6.2)
     declarative (0.0.10)
@@ -875,7 +875,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   coveralls
   csl-styles
-  darlingtonia (= 0.1.1)
+  darlingtonia (= 0.2.0)
   database_cleaner
   devise
   devise-guests (~> 0.6)

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -5,11 +5,8 @@ namespace :mahonia do
     desc 'Run sample import of bepress fixture csv'
     task import_sample_records: :environment do
       parser = MahoniaCsvParser.new(file: File.open('spec/fixtures/bepress_etd_sample.csv'))
+
       Importer.new(parser: parser).import
-      first = Etd.where(title: "Representations and Circuits for Time Based Computation").first.id
-      second = Etd.where(title: "Dielectric functions and optical bandgaps of high-K dielectrics by far ultraviolet spectroscopic ellipsometry").first.id
-      third = Etd.where(title: "Laser  Processing  Optimization for Semiconductor Based Devices").first.id
-      p "Successfully created three Etds, with these ids: #{first}, #{second}, #{third}"
     end
 
     task :bepress_csv, [:filename] => [:environment] do |_task, args|

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,12 +1,22 @@
 # frozen_string_literal: true
-namespace :import do
-  desc 'Run sample import of bepress fixture csv'
-  task import_sample_records: :environment do
-    parser = MahoniaCsvParser.new(file: File.open('spec/fixtures/bepress_etd_sample.csv'))
-    Importer.new(parser: parser).import
-    first = Etd.where(title: "Representations and Circuits for Time Based Computation").first.id
-    second = Etd.where(title: "Dielectric functions and optical bandgaps of high-K dielectrics by far ultraviolet spectroscopic ellipsometry").first.id
-    third = Etd.where(title: "Laser  Processing  Optimization for Semiconductor Based Devices").first.id
-    p "Successfully created three Etds, with these ids: #{first}, #{second}, #{third}"
+
+namespace :mahonia do
+  namespace :import do
+    desc 'Run sample import of bepress fixture csv'
+    task import_sample_records: :environment do
+      parser = MahoniaCsvParser.new(file: File.open('spec/fixtures/bepress_etd_sample.csv'))
+      Importer.new(parser: parser).import
+      first = Etd.where(title: "Representations and Circuits for Time Based Computation").first.id
+      second = Etd.where(title: "Dielectric functions and optical bandgaps of high-K dielectrics by far ultraviolet spectroscopic ellipsometry").first.id
+      third = Etd.where(title: "Laser  Processing  Optimization for Semiconductor Based Devices").first.id
+      p "Successfully created three Etds, with these ids: #{first}, #{second}, #{third}"
+    end
+
+    task :bepress_csv, [:filename] => [:environment] do |_task, args|
+      parser = MahoniaCsvParser.new(file: File.open(args[:filename]))
+      parser.validate!
+
+      Importer.new(parser: parser).import
+    end
   end
 end


### PR DESCRIPTION
This task creates, validates, and imports a parser for the given filename.

Closes #172.

----

The upgrade to `darlingtonia` 0.2.0 gives us access to various validation and
output stream features.

Darlingtonia now handles error and info output during import. We strip the
custom reporting from the example data rake task and defer to this handling.