### PR TITLE
Add integration tests for importer task

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,3 +19,6 @@ RSpec/MultipleExpectations:
 RSpec/ExampleLength:
   Exclude:
     - 'spec/features/**/*'
+RSpec/DescribeClass:
+  Exclude:
+    - 'spec/tasks/**/*'

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -9,11 +9,11 @@ namespace :mahonia do
       Importer.new(parser: parser).import
     end
 
+    desc 'Batch import of bepress formatted csv'
     task :bepress_csv, [:filename] => [:environment] do |_task, args|
       parser = MahoniaCsvParser.new(file: File.open(args[:filename]))
-      parser.validate!
 
-      Importer.new(parser: parser).import
+      Importer.new(parser: parser).import if parser.validate
     end
   end
 end

--- a/spec/fixtures/malformed.csv
+++ b/spec/fixtures/malformed.csv
@@ -1,0 +1,2 @@
+title,description
+fake title, "fake description--quote wrap after delimiter then space is invalid"

--- a/spec/support/shared_contexts/rake.rb
+++ b/spec/support/shared_contexts/rake.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rake'
+
+RSpec.shared_context 'rake' do
+  let(:rake) { Rake::Application.new }
+  let(:name) { self.class.top_level_description }
+
+  def loaded_files_excluding_current_rake_file
+    $LOADED_FEATURES.reject { |file| file == Rails.root.join("#{task_path}.rake").to_s }
+  end
+
+  before do
+    Rake.application = rake
+    Rake.application.rake_require(task_path,
+                                  [Rails.root.to_s],
+                                  loaded_files_excluding_current_rake_file)
+
+    Rake::Task.define_task(:environment)
+  end
+end

--- a/spec/tasks/import_spec.rb
+++ b/spec/tasks/import_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'mahonia:import:bepress_csv' do
+  include_context 'rake'
+
+  subject(:task)  { rake[name] }
+  let(:task_path) { 'lib/tasks/import' }
+  let(:csv_path)  { 'spec/fixtures/bepress_etd_sample.csv' }
+
+  it 'outputs info to stdout' do
+    expect { task.invoke(csv_path) }
+      .to output(/Record created/)
+      .to_stdout_from_any_process
+  end
+
+  it 'creates exactly 3 Etds' do
+    expect { task.invoke(csv_path) }
+      .to change { Etd.count }
+      .by(3)
+  end
+
+  context 'with an invalid file' do
+    let(:csv_path) { 'spec/fixtures/malformed.csv' }
+
+    it 'outputs validation failures to stdout' do
+      expect { task.invoke(csv_path) }
+        .to output(/MalformedCSV.*line 2/)
+        .to_stdout_from_any_process
+    end
+
+    it 'does not create items' do
+      expect { task.invoke(csv_path) }
+        .not_to change { Etd.count }
+    end
+  end
+end


### PR DESCRIPTION
An integration test for importing Etds via the rake task is added. Validation for invalid CSV is also included.

Rake task tests are supported by an RSpec shared context which sets up the task. The convention is that rake tasks have a top_level_description of the task name, so a rubocop rule preventing this is disabled for the `spec/tasks` directory.