### PR TITLE
Skip records with no data on import

### DIFF
--- a/app/importers/mahonia_csv_parser.rb
+++ b/app/importers/mahonia_csv_parser.rb
@@ -7,7 +7,11 @@ class MahoniaCsvParser < Darlingtonia::CsvParser
     file.rewind
     # use the MahoniaMapper
     CSV.parse(file.read, headers: true).each do |row|
+      next if row.to_h.values.all?(&:nil?)
       yield Darlingtonia::InputRecord.from(metadata: row, mapper: MahoniaMapper.new)
     end
+  rescue CSV::MalformedCSVError
+    # error reporting for this case is handled by validation
+    []
   end
 end

--- a/spec/fixtures/malformed.csv
+++ b/spec/fixtures/malformed.csv
@@ -1,0 +1,2 @@
+title,description
+fake title, "fake description--quote wrap after delimiter then space is invalid"

--- a/spec/importer/mahonia_csv_parser_spec.rb
+++ b/spec/importer/mahonia_csv_parser_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MahoniaCsvParser do
+  subject(:parser) { described_class.new(file: file) }
+  let(:file)       { File.open(csv_path) }
+  let(:csv_path)   { 'spec/fixtures/bepress_etd_sample.csv' }
+
+  describe '#records' do
+    it 'skips records with no values' do
+      expect(parser.records.count).to eq 3
+    end
+  end
+
+  describe '#validate' do
+    it 'is valid' do
+      expect(parser.validate).to be_truthy
+    end
+
+    context 'with invalid csv' do
+      let(:csv_path) { 'spec/fixtures/malformed.csv' }
+
+      it 'has CSV::MalformedCSVError error' do
+        expect { parser.validate }
+          .to change { parser.errors }
+          .to include have_attributes(name: CSV::MalformedCSVError)
+      end
+    end
+  end
+end

--- a/spec/importer/mahonia_csv_parser_spec.rb
+++ b/spec/importer/mahonia_csv_parser_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe MahoniaCsvParser do
     it 'skips records with no values' do
       expect(parser.records.count).to eq 3
     end
+
+    context 'with invalid csv' do
+      let(:csv_path) { 'spec/fixtures/malformed.csv' }
+
+      it 'is empty' do
+        expect(parser.records.to_a).to be_empty
+      end
+    end
   end
 
   describe '#validate' do


### PR DESCRIPTION
Our sample BePress exports contain rows with only delimiters. Rather than fail
validation on these rows, we prefer to skip them entirely. We do this at the
`Parser` layer, so anything consuming `Parser#records` (validators, importers,
etc...) will treat these rows as non-records.