### PR TITLE
Format Darlingtonia log/stream output

### DIFF
--- a/app/importers/message_stream.rb
+++ b/app/importers/message_stream.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+##
+# Formats messages from the import process for nicer output
+class MessageStream
+  def <<(msg)
+    STDOUT << format_message(msg)
+  end
+
+  def format_message(msg)
+    msg.to_s + "\n"
+  end
+end

--- a/config/initializers/darlingtonia.rb
+++ b/config/initializers/darlingtonia.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Darlingtonia.config do |config|
+  config.default_error_stream = MessageStream.new
+  config.default_info_stream  = MessageStream.new
+end

--- a/spec/tasks/import_spec.rb
+++ b/spec/tasks/import_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'mahonia:import:bepress_csv' do
 
   it 'outputs info to stdout' do
     expect { task.invoke(csv_path) }
-      .to output(/Record created/)
+      .to output(/^Record created/)
       .to_stdout_from_any_process
   end
 


### PR DESCRIPTION
We want the log output to be formatted to include each message on a newline. To
achieve this, we use a custom `MessageStream` to wrap `STDOUT` and format each
message before appending it.