### PR TITLE
fixing bug by adding missing check for nil in mapper creator method

### DIFF
--- a/app/importers/mahonia_mapper.rb
+++ b/app/importers/mahonia_mapper.rb
@@ -29,7 +29,7 @@ class MahoniaMapper < Darlingtonia::HashMapper
   end
 
   def creator
-    return if metadata['author1_fname'].nil? && metadata['author1_lname']
+    return if metadata['author1_fname'].nil? && metadata['author1_lname'].nil?
     Array("#{metadata['author1_fname']} #{metadata['author1_lname']}")
   end
 

--- a/spec/importer/mahonia_mapper_spec.rb
+++ b/spec/importer/mahonia_mapper_spec.rb
@@ -50,6 +50,18 @@ A far ultraviolet (UV) spectroscopic ellipsometer  system working up to 9 eV has
     expect(mapper.creator).to eq(["Marie Curie"])
   end
 
+  it "won't map creator if author1_fname and author1_lname are both nil" do
+    mapper.metadata = { "author1_fname" => nil, "author1_lname" => nil }
+
+    expect(mapper.creator.nil?).to be_truthy
+  end
+
+  it "will map creator if only author1_lname is nil" do
+    mapper.metadata = { "author1_fname" => "Marie", "author1_lname" => nil }
+
+    expect(mapper.creator).to eq(["Marie "])
+  end
+
   it "doesn't provide a field for terms not found in BEPRESS_TERMS_MAP" do
     mapper.metadata = { "title" => "War and Peace" }
 


### PR DESCRIPTION
This method's tests are an interim step towards better string handling, which would strip whitespaces if only one name is supplied, which is expected to be part of the work required for adding more authors to the mapper.