### PR TITLE
Upgrade `darlingtonia` to 1.0.0-rc1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ end
 ruby '~> 2.4.2'
 
 # DCE importer
-gem 'darlingtonia', '0.3.0'
+gem 'darlingtonia', '1.0.0-rc1'
 gem 'dotenv-rails'
 gem 'honeybadger', '~> 3.1'
 gem 'hydra-role-management', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,7 +203,7 @@ GEM
     csl-styles (1.0.1.8)
       csl (~> 1.0)
     daemons (1.2.6)
-    darlingtonia (0.3.0)
+    darlingtonia (1.0.0.pre.rc1)
       active-fedora (>= 11.0, <= 12.99)
     database_cleaner (1.6.2)
     declarative (0.0.10)
@@ -859,7 +859,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   coveralls
   csl-styles
-  darlingtonia (= 0.3.0)
+  darlingtonia (= 1.0.0.pre.rc1)
   database_cleaner
   devise (~> 4.4, >= 4.4.1)
   devise-guests (~> 0.6)


### PR DESCRIPTION
This is in preparation for an rc1 of this project. We are hoping to release `darlingtonia` 1.0.0 shortly and bump to that as the final dependency version for this development cycle.