### PR TITLE
Force downcase in MESH authority queries

### DIFF
--- a/app/models/qa/authorities/mesh.rb
+++ b/app/models/qa/authorities/mesh.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require Qa::Engine.root.join('lib', 'qa', 'authorities', 'mesh')
+
+module Qa
+  module Authorities
+    ##
+    # Monkeypatch the built in MESH authority to downcase terms.
+    #
+    # @see https://github.com/samvera/questioning_authority/issues/158
+    class Mesh
+      def search(query)
+        Qa::SubjectMeshTerm
+          .where('term_lower LIKE ?', "#{query.to_s.downcase}%")
+          .limit(10)
+          .map { |t| { id: t.term_id, label: t.term } }
+      end
+    end
+  end
+end

--- a/spec/features/autocomplete_mesh_spec.rb
+++ b/spec/features/autocomplete_mesh_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature 'Autocomplete MeSH terms', mesh: true, js: true do
     click_on 'Additional fields'
 
     # Check that we get the correct autocompletion from QA
-    find('#etd_subject').send_keys 'sulfameraz'
+    find('#etd_subject').send_keys 'SuLFamerAZ'
     expect(page).to have_content('Sulfamerazine')
 
     # Fill out the rest of the form


### PR DESCRIPTION
MESH ids are in lowercase. Since query is case sensitive, we need to downcase
query terms in order to prevent false negatives based on typist idiosyncracies.

Since it's not possible to redirect authorities in `Qa` due to the `TermsController`
behavior (https://github.com/samvera/questioning_authority/issues/137), we
simply monkeypatch the existing `Qa::Authorities::Mesh` class.

Closes #244.