### PR TITLE
Create an admin set in test setup for virus check features

### DIFF
--- a/spec/features/virus_scan_spec.rb
+++ b/spec/features/virus_scan_spec.rb
@@ -4,8 +4,13 @@ include Warden::Test::Helpers
 
 RSpec.feature 'Virus Scanning', :clean, :js, :virus_scan do
   let(:admin) { FactoryBot.create(:admin) }
-  before { login_as admin }
-  after  { logout }
+
+  before do
+    login_as admin
+    AdminSet.find_or_create_default_admin_set_id
+  end
+
+  after { logout }
 
   let(:safe_path)  { "#{fixture_path}/files/pdf-sample.pdf" }
   let(:virus_path) { "#{fixture_path}/virus_check.txt" }


### PR DESCRIPTION
We don't seem to need an admin set for the actual virus check feature tests, but
if one has been created and then the database cleaned before this test runs, an
error occurs (404 from Fedora). This prevents failures in this case when running
the full test suite.