### PR TITLE
Bump `hyrax-spec` to 0.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,7 @@ group :development, :test do
   gem 'database_cleaner'
   gem 'fcrepo_wrapper'
   gem 'ffaker'
-  gem 'hyrax-spec', '~> 0.3.0'
+  gem 'hyrax-spec', "~> 0.3.2"
   gem 'rspec-rails'
   gem 'webmock', '~> 3.1', '>= 3.1.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -409,7 +409,7 @@ GEM
       select2-rails (~> 3.5)
       signet
       tinymce-rails (~> 4.1)
-    hyrax-spec (0.3.0)
+    hyrax-spec (0.3.2)
       rspec (~> 3.6)
     i18n (0.9.3)
       concurrent-ruby (~> 1.0)
@@ -876,7 +876,7 @@ DEPENDENCIES
   honeybadger (~> 3.1)
   hydra-role-management (~> 1.0)
   hyrax (~> 2.0.0)
-  hyrax-spec (~> 0.3.0)
+  hyrax-spec (~> 0.3.2)
   jbuilder (~> 2.5)
   jquery-rails (~> 4.3)
   listen (~> 3.0.5)

--- a/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
@@ -135,7 +135,6 @@ RSpec.describe 'hyrax/base/_form_metadata.html.erb', type: :view do
 
     it 'has licenses' do
       expect(page).to have_form_field(:license)
-        .as_single_valued
         .on_model(work.class)
         .with_label('License')
         .and_options(*license_uris)


### PR DESCRIPTION
This fixes a bug in the `have_form_field` matcher, allowing us to correctly
specify the license behavior in the form metadata tests.