### PR TITLE
Ok computer clamav

### DIFF
--- a/app/lib/ok_computer/clamav_service_check.rb
+++ b/app/lib/ok_computer/clamav_service_check.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'honeybadger'
+
+module OkComputer
+  class ClamavServiceCheck < OkComputer::Check
+    def check
+      raise VirusScannerError, 'False positive in example.csv' if
+        Mahonia::VirusScanner.new('spec/fixtures/example.csv').infected?
+
+      raise VirusScannerError, 'False negative in virus_check.txt' unless
+        Mahonia::VirusScanner.new('spec/fixtures/virus_check.txt').infected?
+    rescue => exception
+      Honeybadger.notify(exception)
+      mark_failure
+      mark_message exception.message
+    end
+
+    class VirusScannerError < RuntimeError; end
+  end
+end

--- a/config/initializers/clamav.rb
+++ b/config/initializers/clamav.rb
@@ -7,7 +7,7 @@ if Rails.env.production?
     daemonize: true,
     error_clamscan_missing: true,
     error_file_missing: true,
-    error_file_virus: true,
+    error_file_virus: false,
     fdpass: true
   )
 end

--- a/spec/lib/ok_computer/clamav_service_check_spec.rb
+++ b/spec/lib/ok_computer/clamav_service_check_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe OkComputer::ClamavServiceCheck do
+  subject(:check) { described_class.new }
+
+  describe '#check' do
+    context 'in a failing state' do
+      it 'marks failure occurred' do
+        expect { check.check }
+          .to change { check.failure_occurred }
+          .to(true)
+      end
+    end
+
+    context 'with a working Clamby interface', :virus_scan do
+      it 'marks success' do
+        expect { check.check }.not_to change { check.success? }.from(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds an OkComputer endpoint that verifies that a (fake) virus file is properly
detected by the virus scanner, and that a non-virus does not yields a false
positive.

We are relying on the documented behavior that `#virus?` returns `true` when a
virus is found. Due to our configuration, we were instead encountering
`Exceptions::VirusDetected`; this happens even when a virus is not detected,
whenever the system call gives a non-0 exit code.

Changing to `error_file_virus: false` avoids the unexpected exceptions. We still
have a hair-trigger virus scanner that treats various system failure states as
positive virus scans. A ticket is open for this at
kobaltz/clamby#12.

Connected to #292.