### PR TITLE
Display DOI/identifier as an unlinked field

### DIFF
--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -7,7 +7,7 @@
 <%= presenter.attribute_to_html(:institution, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:school, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:language, render_as: :faceted) %>
-<%= presenter.attribute_to_html(:identifier, render_as: :linked, search_field: 'identifier_tesim') %>
+<%= presenter.attribute_to_html(:identifier, search_field: 'identifier_tesim') %>
 <%= presenter.attribute_to_html(:keyword, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:date_created, render_as: :linked, search_field: 'date_created_desim') %>
 <%= presenter.attribute_to_html(:date) %>

--- a/spec/views/hyrax/base/_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_metadata.html.erb_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'hyrax/base/_metadata.html.erb', type: :view do
   it { is_expected.to have_show_field(:degree).with_values(*work.degree).and_label('Degree Name') }
   it { is_expected.to have_show_field(:department).with_values(*work.department).and_label('Department') }
   it { is_expected.to have_show_field(:school).with_values(*work.school).and_label('School') }
+  it { is_expected.to have_show_field(:identifier).with_values(*work.identifier).and_label('Identifier') }
   it { is_expected.to have_show_field(:institution).with_values(*work.institution).and_label('Institution') }
   it { is_expected.to have_show_field(:keyword).with_values(*work.keyword).and_label('Keyword') }
   it { is_expected.to have_show_field(:language).with_values(*work.language).and_label('Language') }


### PR DESCRIPTION
The DOI (`#identifier`) previously displayed as a link to a facet. In general,
this is not a good approach. We disable the identifier link in the
`attribute_rows` partial.

Closes #291 