### PR TITLE
Use dotenv to manage database credentials

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,7 @@
 default: &default
   adapter:  postgresql
   encoding: unicode
-  pool:     5
+  pool:     25
   timeout:  5000
 
 development:
@@ -15,8 +15,10 @@ test:
   <<: *default
   database: mahonia_test
 
+# Note: production credentials are stored in .env.production file
+# on the server, originally configured by ansible
 production:
   <<: *default
-  database: mahonia_production
-  username: mahonia
-  password: password1
+  database: <%= ENV['DATABASE_NAME'] %>
+  username: <%= ENV['DATABASE_USERNAME'] %>
+  password: <%= ENV['DATABASE_PASSWORD'] %>

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -24,7 +24,6 @@ set :branch, ENV['REVISION'] || ENV['BRANCH_NAME'] || ENV['BRANCH'] || 'master'
 append :linked_dirs, "log"
 append :linked_dirs, "public/assets"
 
-append :linked_files, "config/database.yml"
 append :linked_files, "config/secrets.yml"
 append :linked_files, ".env.production"
 


### PR DESCRIPTION
Increase database connection pool to 25 to match
the number of threads sidekiq spins up by default.
This will prevent connection pool errors in production.

Closes #297 